### PR TITLE
feat: project scaffolding — Cargo.toml, module stubs, core types

### DIFF
--- a/.ralph/backlog.json
+++ b/.ralph/backlog.json
@@ -1,5 +1,169 @@
 {
-  "issues": [],
-  "last_groomed_at": null,
-  "priority_order": []
+  "issues": [
+    {
+      "number": 1,
+      "title": "[scaffold] Project scaffolding \u2014 Cargo.toml, module stubs, directory structure",
+      "labels": [
+        "enhancement"
+      ],
+      "priority": "high"
+    },
+    {
+      "number": 2,
+      "title": "[engine] Core data types \u2014 Song, Track, Pattern, NoteEvent",
+      "labels": [
+        "enhancement"
+      ],
+      "priority": "high"
+    },
+    {
+      "number": 3,
+      "title": "[engine] Music theory module \u2014 scales, chords, intervals",
+      "labels": [
+        "enhancement"
+      ],
+      "priority": "high"
+    },
+    {
+      "number": 4,
+      "title": "[engine] Rhythm engine \u2014 groove patterns, strum, humanization",
+      "labels": [
+        "enhancement"
+      ],
+      "priority": "high"
+    },
+    {
+      "number": 5,
+      "title": "[engine] Melody generator \u2014 contour, targeting, voice leading",
+      "labels": [
+        "enhancement"
+      ],
+      "priority": "medium"
+    },
+    {
+      "number": 6,
+      "title": "[engine] Drum pattern generator \u2014 genre-appropriate grooves",
+      "labels": [
+        "enhancement"
+      ],
+      "priority": "medium"
+    },
+    {
+      "number": 7,
+      "title": "[engine] Bass line generator \u2014 walking lines, approach notes",
+      "labels": [
+        "enhancement"
+      ],
+      "priority": "medium"
+    },
+    {
+      "number": 8,
+      "title": "[engine] Arrangement \u2014 song structure, transitions, dynamics",
+      "labels": [
+        "enhancement"
+      ],
+      "priority": "medium"
+    },
+    {
+      "number": 9,
+      "title": "[engine] Top-level composer orchestrator",
+      "labels": [
+        "enhancement"
+      ],
+      "priority": "medium"
+    },
+    {
+      "number": 10,
+      "title": "[state] Shared state, snapshots, undo/redo",
+      "labels": [
+        "enhancement"
+      ],
+      "priority": "high"
+    },
+    {
+      "number": 11,
+      "title": "[midi] MIDI file export via midly",
+      "labels": [
+        "enhancement"
+      ],
+      "priority": "high"
+    },
+    {
+      "number": 12,
+      "title": "[cli] CLI commands via clap",
+      "labels": [
+        "enhancement"
+      ],
+      "priority": "medium"
+    },
+    {
+      "number": 13,
+      "title": "[gui] Iced GUI application \u2014 dark theme, pattern view",
+      "labels": [
+        "enhancement"
+      ],
+      "priority": "medium"
+    },
+    {
+      "number": 14,
+      "title": "[bridge] TCP bridge server for Bitwig connection",
+      "labels": [
+        "enhancement"
+      ],
+      "priority": "low"
+    },
+    {
+      "number": 15,
+      "title": "[bitwig] Java Bitwig Studio extension",
+      "labels": [
+        "enhancement"
+      ],
+      "priority": "low"
+    },
+    {
+      "number": 16,
+      "title": "[ci] CI/CD pipeline \u2014 build, test, clippy, format",
+      "labels": [
+        "enhancement"
+      ],
+      "priority": "low"
+    },
+    {
+      "number": 17,
+      "title": "[testing] Core test suite \u2014 theory, determinism, CLI, MIDI round-trip",
+      "labels": [
+        "testing"
+      ],
+      "priority": "medium"
+    },
+    {
+      "number": 18,
+      "title": "[docs] Reference defaults and presets",
+      "labels": [
+        "documentation"
+      ],
+      "priority": "medium"
+    }
+  ],
+  "last_groomed_at": "2026-03-12T06:44:27.411050+00:00",
+  "priority_order": [
+    1,
+    2,
+    3,
+    10,
+    11,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    12,
+    16,
+    13,
+    14,
+    17,
+    18,
+    15
+  ]
 }

--- a/.ralph/metrics.json
+++ b/.ralph/metrics.json
@@ -1,6 +1,6 @@
 {
-  "total_loops": 0,
-  "total_issues_created": 0,
+  "total_loops": 1,
+  "total_issues_created": 18,
   "total_prs_created": 0,
   "total_prs_merged": 0,
   "total_errors": 0,
@@ -8,9 +8,9 @@
   "last_rate_limit_at": null,
   "backoff_until": null,
   "phases_completed": {
-    "research": 0,
-    "plan": 0,
-    "orchestrate": 0,
+    "research": 1,
+    "plan": 1,
+    "orchestrate": 1,
     "work": 0,
     "review": 0,
     "monitor": 0

--- a/.ralph/status.json
+++ b/.ralph/status.json
@@ -1,12 +1,19 @@
 {
-  "phase": "idle",
-  "loop_count": 0,
-  "last_phase_completed": null,
+  "phase": "work",
+  "loop_count": 1,
+  "last_phase_completed": "orchestrate",
   "last_error": null,
-  "started_at": null,
-  "updated_at": "2026-03-12T06:32:36.671103+00:00",
-  "current_issue": null,
-  "current_branch": null,
+  "started_at": "2026-03-12T06:37:12.894596+00:00",
+  "updated_at": "2026-03-12T06:44:27.412990+00:00",
+  "current_issue": {
+    "number": 1,
+    "title": "[scaffold] Project scaffolding \u2014 Cargo.toml, module stubs, directory structure",
+    "labels": [
+      "enhancement"
+    ],
+    "reason": "Foundational issue \u2014 every other issue depends on the project structure, Cargo.toml, and module stubs being in place. No dependencies, no open PR, highest priority in backlog."
+  },
+  "current_branch": "issue-1-scaffold-project-scaffolding-cargotoml-module",
   "current_pr": null,
   "halted": false,
   "halt_reason": null

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "copper-hollow"
+version = "0.0.1"
+edition = "2021"
+description = "Folk/indie/alt-country MIDI composition engine"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+midly = "0.5"
+rand = "0.8"
+rand_chacha = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -1,0 +1,4 @@
+pub mod protocol;
+
+// TCP server for Bitwig Studio connection on 127.0.0.1:9876.
+// Implementation will follow in a future issue.

--- a/src/bridge/protocol.rs
+++ b/src/bridge/protocol.rs
@@ -1,0 +1,2 @@
+// JSON message types for the Bitwig bridge protocol.
+// Implementation will follow in a future issue.

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,0 +1,23 @@
+use anyhow::Result;
+
+use super::{Cli, Commands};
+
+/// Execute a CLI command and print JSON to stdout.
+pub fn execute(command: &Commands, _args: &Cli) -> Result<()> {
+    let response = match command {
+        Commands::GetState => serde_json::json!({"ok": true, "data": "not yet implemented"}),
+        Commands::GetSong => serde_json::json!({"ok": true, "data": "not yet implemented"}),
+        Commands::ListScales => serde_json::json!({"ok": true, "data": "not yet implemented"}),
+        Commands::ListInstruments => {
+            serde_json::json!({"ok": true, "data": "not yet implemented"})
+        }
+        Commands::ListStrumPatterns => {
+            serde_json::json!({"ok": true, "data": "not yet implemented"})
+        }
+        Commands::ListParts => serde_json::json!({"ok": true, "data": "not yet implemented"}),
+        _ => serde_json::json!({"ok": true, "data": "not yet implemented"}),
+    };
+
+    println!("{}", serde_json::to_string_pretty(&response)?);
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,310 @@
+pub mod commands;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "copper-hollow", about = "Folk/indie MIDI composition engine")]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+
+    /// Force headless mode (don't connect to GUI).
+    #[arg(long)]
+    pub headless: bool,
+
+    /// Set RNG seed.
+    #[arg(long)]
+    pub seed: Option<u64>,
+
+    /// Pretty-print JSON output.
+    #[arg(long)]
+    pub json_pretty: bool,
+
+    /// Suppress non-essential output.
+    #[arg(short, long)]
+    pub quiet: bool,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    // -- State Inspection --
+    /// Full state dump.
+    GetState,
+    /// Get a specific track by index.
+    GetTrack { index: usize },
+    /// Get a pattern for a track and part.
+    GetPattern { track: usize, part: String },
+    /// Get current song info.
+    GetSong,
+    /// List available scales.
+    ListScales,
+    /// List available instruments.
+    ListInstruments,
+    /// List available progressions for a part.
+    ListProgressions { part: String },
+    /// List strum pattern presets.
+    ListStrumPatterns,
+    /// List song parts.
+    ListParts,
+
+    // -- Composition --
+    /// Randomize with a new seed.
+    Randomize {
+        #[arg(long)]
+        track: Option<usize>,
+        #[arg(long)]
+        part: Option<String>,
+        #[arg(long)]
+        seed: Option<u64>,
+    },
+    /// Recompose all (same settings, same seed = same output).
+    Compose,
+    /// Next suggestion (increment seed, recompose).
+    Next {
+        #[arg(long)]
+        track: Option<usize>,
+        #[arg(long)]
+        part: Option<String>,
+    },
+
+    // -- Song Settings --
+    /// Set tempo in BPM.
+    SetTempo { bpm: f64 },
+    /// Set rhythm scale (root and type).
+    SetRhythmScale { root: String, scale_type: String },
+    /// Set lead scale.
+    SetLeadScale {
+        root: String,
+        scale_type: String,
+        #[arg(long)]
+        passing_tones: Option<Vec<u8>>,
+    },
+    /// Set swing amount (0.0–1.0).
+    SetSwing { amount: f32 },
+    /// Set song title.
+    SetTitle { title: String },
+    /// Set song structure (ordered part names).
+    SetStructure { parts: Vec<String> },
+    /// Set strum pattern by name.
+    SetStrumPattern { name: String },
+
+    // -- Chord Progressions --
+    /// Set chord progression for a part (Roman numerals).
+    SetProgression { part: String, degrees: Vec<String> },
+
+    // -- Track Settings --
+    /// Set track properties.
+    SetTrack {
+        index: usize,
+        #[arg(long)]
+        name: Option<String>,
+        #[arg(long)]
+        role: Option<String>,
+        #[arg(long)]
+        instrument: Option<String>,
+        #[arg(long)]
+        voicing: Option<String>,
+    },
+    /// Mute a track.
+    Mute { track: usize },
+    /// Unmute a track.
+    Unmute { track: usize },
+    /// Solo a track.
+    Solo { track: usize },
+    /// Unsolo a track.
+    Unsolo { track: usize },
+    /// Activate a track in a part.
+    Activate { track: usize, part: String },
+    /// Deactivate a track in a part.
+    Deactivate { track: usize, part: String },
+
+    // -- Direct MIDI Editing --
+    /// Set entire pattern (replaces all notes). Events as JSON array string.
+    SetPattern {
+        track: usize,
+        part: String,
+        #[arg(long)]
+        events: String,
+    },
+    /// Add a single note to an existing pattern.
+    AddNote {
+        track: usize,
+        part: String,
+        #[arg(long)]
+        tick: u32,
+        #[arg(long)]
+        note: u8,
+        #[arg(long)]
+        velocity: u8,
+        #[arg(long)]
+        duration: u32,
+    },
+    /// Remove notes matching criteria.
+    RemoveNotes {
+        track: usize,
+        part: String,
+        #[arg(long)]
+        tick: Option<u32>,
+        #[arg(long)]
+        tick_range: Option<Vec<u32>>,
+        #[arg(long)]
+        note_range: Option<Vec<u8>>,
+    },
+    /// Modify notes matching criteria.
+    ModifyNotes {
+        track: usize,
+        part: String,
+        #[arg(long)]
+        tick_range: Option<Vec<u32>>,
+        #[arg(long)]
+        note: Option<u8>,
+        #[arg(long)]
+        velocity_add: Option<i8>,
+        #[arg(long)]
+        transpose: Option<i8>,
+        #[arg(long)]
+        shift_ticks: Option<i32>,
+        #[arg(long)]
+        set_velocity: Option<u8>,
+    },
+    /// Set CC automation. Events as JSON array string.
+    SetCc {
+        track: usize,
+        part: String,
+        #[arg(long)]
+        cc: u8,
+        #[arg(long)]
+        events: String,
+    },
+    /// Set pitch bend. Events as JSON array string.
+    SetPitchbend {
+        track: usize,
+        part: String,
+        #[arg(long)]
+        events: String,
+    },
+    /// Copy a pattern from one part to another.
+    CopyPattern {
+        track: usize,
+        from: String,
+        to: String,
+    },
+    /// Clear a pattern.
+    ClearPattern { track: usize, part: String },
+
+    // -- Scale Degree Toggling --
+    /// Toggle a scale degree on/off.
+    ToggleDegree { scale: String, degree: usize },
+    /// Add a passing tone (semitone offset from root).
+    AddPassingTone { scale: String, semitone: u8 },
+    /// Remove a passing tone.
+    RemovePassingTone { scale: String, semitone: u8 },
+
+    // -- History --
+    /// Undo last change.
+    Undo,
+    /// Redo last undone change.
+    Redo,
+    /// List all snapshots.
+    History,
+    /// Jump to a snapshot index.
+    GotoSnapshot { index: usize },
+
+    // -- Export --
+    /// Export song to MIDI file.
+    ExportMidi {
+        path: String,
+        #[arg(long)]
+        track: Option<usize>,
+        #[arg(long)]
+        part: Option<String>,
+    },
+
+    // -- Transport (requires Bitwig connection) --
+    /// Start playback.
+    Play,
+    /// Stop playback.
+    Stop,
+    /// Get transport status.
+    TransportStatus,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn parse_no_args_is_gui_mode() {
+        let cli = Cli::try_parse_from(["copper-hollow"]).unwrap();
+        assert!(cli.command.is_none());
+    }
+
+    #[test]
+    fn parse_get_state() {
+        let cli = Cli::try_parse_from(["copper-hollow", "get-state"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::GetState)));
+    }
+
+    #[test]
+    fn parse_set_tempo() {
+        let cli = Cli::try_parse_from(["copper-hollow", "set-tempo", "105"]).unwrap();
+        if let Some(Commands::SetTempo { bpm }) = cli.command {
+            assert!((bpm - 105.0).abs() < f64::EPSILON);
+        } else {
+            panic!("expected SetTempo");
+        }
+    }
+
+    #[test]
+    fn parse_randomize_with_flags() {
+        let cli = Cli::try_parse_from([
+            "copper-hollow",
+            "randomize",
+            "--track",
+            "4",
+            "--part",
+            "chorus",
+            "--seed",
+            "12345",
+        ])
+        .unwrap();
+        if let Some(Commands::Randomize { track, part, seed }) = cli.command {
+            assert_eq!(track, Some(4));
+            assert_eq!(part.as_deref(), Some("chorus"));
+            assert_eq!(seed, Some(12345));
+        } else {
+            panic!("expected Randomize");
+        }
+    }
+
+    #[test]
+    fn parse_export_midi() {
+        let cli = Cli::try_parse_from([
+            "copper-hollow",
+            "export-midi",
+            "/tmp/song.mid",
+            "--track",
+            "4",
+            "--part",
+            "chorus",
+        ])
+        .unwrap();
+        if let Some(Commands::ExportMidi { path, track, part }) = cli.command {
+            assert_eq!(path, "/tmp/song.mid");
+            assert_eq!(track, Some(4));
+            assert_eq!(part.as_deref(), Some("chorus"));
+        } else {
+            panic!("expected ExportMidi");
+        }
+    }
+
+    #[test]
+    fn parse_global_options() {
+        let cli =
+            Cli::try_parse_from(["copper-hollow", "--headless", "--seed", "42", "get-state"])
+                .unwrap();
+        assert!(cli.headless);
+        assert_eq!(cli.seed, Some(42));
+    }
+}

--- a/src/engine/arrangement.rs
+++ b/src/engine/arrangement.rs
@@ -1,0 +1,2 @@
+// Song structure, section transitions, and dynamics scaling.
+// Implementation will follow in a future issue.

--- a/src/engine/bass.rs
+++ b/src/engine/bass.rs
@@ -1,0 +1,2 @@
+// Bass line generation: walking, root-fifth, approach notes.
+// Implementation will follow in a future issue.

--- a/src/engine/composer.rs
+++ b/src/engine/composer.rs
@@ -1,0 +1,47 @@
+use serde::{Deserialize, Serialize};
+
+/// Top-level composition orchestrator.
+/// Holds the RNG seed so that composition is fully deterministic.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Composer {
+    seed: u64,
+}
+
+impl Composer {
+    pub fn new(seed: u64) -> Self {
+        Self { seed }
+    }
+
+    pub fn seed(&self) -> u64 {
+        self.seed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::Rng;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    #[test]
+    fn same_seed_produces_same_output() {
+        let mut rng1 = ChaCha8Rng::seed_from_u64(42);
+        let mut rng2 = ChaCha8Rng::seed_from_u64(42);
+
+        let notes1: Vec<u8> = (0..32).map(|_| rng1.gen_range(40..80)).collect();
+        let notes2: Vec<u8> = (0..32).map(|_| rng2.gen_range(40..80)).collect();
+
+        assert_eq!(notes1, notes2, "same seed must produce identical output");
+    }
+
+    #[test]
+    fn different_seeds_produce_different_output() {
+        let mut rng1 = ChaCha8Rng::seed_from_u64(42);
+        let mut rng2 = ChaCha8Rng::seed_from_u64(99);
+
+        let notes1: Vec<u8> = (0..32).map(|_| rng1.gen_range(40..80)).collect();
+        let notes2: Vec<u8> = (0..32).map(|_| rng2.gen_range(40..80)).collect();
+
+        assert_ne!(notes1, notes2, "different seeds should differ");
+    }
+}

--- a/src/engine/drums.rs
+++ b/src/engine/drums.rs
@@ -1,0 +1,2 @@
+// Per-instrument drum pattern generation by song part.
+// Implementation will follow in a future issue.

--- a/src/engine/melody.rs
+++ b/src/engine/melody.rs
@@ -1,0 +1,2 @@
+// Melodic contour generation, chord tone targeting, voice leading.
+// Implementation will follow in a future issue.

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,0 +1,19 @@
+pub mod arrangement;
+pub mod bass;
+pub mod composer;
+pub mod drums;
+pub mod melody;
+pub mod rhythm;
+pub mod song;
+pub mod theory;
+
+/// MIDI ticks per beat (quarter note).
+pub const TICKS_PER_BEAT: u32 = 480;
+/// MIDI ticks per bar in 4/4 time.
+pub const TICKS_PER_BAR: u32 = 1920;
+/// MIDI note number for Middle C (C3 in Bitwig).
+pub const MIDDLE_C: u8 = 60;
+/// MIDI note for single-instrument percussion tracks.
+pub const DRUM_NOTE: u8 = 36;
+/// Pitch bend center value.
+pub const PITCH_BEND_CENTER: u16 = 8192;

--- a/src/engine/rhythm.rs
+++ b/src/engine/rhythm.rs
@@ -1,0 +1,2 @@
+// Groove patterns, strum generation, humanization, and swing.
+// Implementation will follow in a future issue.

--- a/src/engine/song.rs
+++ b/src/engine/song.rs
@@ -1,0 +1,278 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use super::theory::{ChordDegree, Scale};
+
+// ---------------------------------------------------------------------------
+// SongPart
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SongPart {
+    Intro,
+    Verse,
+    #[serde(rename = "prechorus")]
+    PreChorus,
+    Chorus,
+    Bridge,
+    Outro,
+}
+
+impl SongPart {
+    /// Default bar count for this part.
+    pub fn typical_bars(self) -> u32 {
+        match self {
+            SongPart::Intro => 4,
+            SongPart::Verse => 8,
+            SongPart::PreChorus => 4,
+            SongPart::Chorus => 8,
+            SongPart::Bridge => 8,
+            SongPart::Outro => 4,
+        }
+    }
+}
+
+impl FromStr for SongPart {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "intro" => Ok(SongPart::Intro),
+            "verse" => Ok(SongPart::Verse),
+            "prechorus" | "pre_chorus" => Ok(SongPart::PreChorus),
+            "chorus" => Ok(SongPart::Chorus),
+            "bridge" => Ok(SongPart::Bridge),
+            "outro" => Ok(SongPart::Outro),
+            _ => Err(anyhow::anyhow!("unknown song part: {s}")),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// InstrumentType
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InstrumentType {
+    // Melodic
+    AcousticGuitar,
+    ElectricGuitar,
+    ElectricBass,
+    AcousticBass,
+    PedalSteel,
+    Mandolin,
+    Banjo,
+    HammondOrgan,
+    Piano,
+    Pad,
+    // Percussion
+    Kick,
+    Snare,
+    HiHat,
+    OpenHiHat,
+    Clap,
+    Tambourine,
+    Cowbell,
+    Shaker,
+    RideCymbal,
+    CrashCymbal,
+    Toms,
+    Rimshot,
+}
+
+impl InstrumentType {
+    /// Whether this is a percussion instrument.
+    pub fn is_percussion(self) -> bool {
+        matches!(
+            self,
+            InstrumentType::Kick
+                | InstrumentType::Snare
+                | InstrumentType::HiHat
+                | InstrumentType::OpenHiHat
+                | InstrumentType::Clap
+                | InstrumentType::Tambourine
+                | InstrumentType::Cowbell
+                | InstrumentType::Shaker
+                | InstrumentType::RideCymbal
+                | InstrumentType::CrashCymbal
+                | InstrumentType::Toms
+                | InstrumentType::Rimshot
+        )
+    }
+
+    /// Comfortable MIDI note range (low, high) for melodic instruments.
+    /// Returns `(36, 36)` for percussion (fixed MIDI note C1).
+    pub fn midi_range(self) -> (u8, u8) {
+        match self {
+            InstrumentType::AcousticGuitar => (40, 79),
+            InstrumentType::ElectricGuitar => (40, 84),
+            InstrumentType::ElectricBass => (28, 55),
+            InstrumentType::AcousticBass => (28, 50),
+            InstrumentType::PedalSteel => (40, 79),
+            InstrumentType::Mandolin => (55, 86),
+            InstrumentType::Banjo => (48, 79),
+            InstrumentType::HammondOrgan => (36, 84),
+            InstrumentType::Piano => (28, 96),
+            InstrumentType::Pad => (36, 84),
+            _ => (36, 36), // percussion: fixed MIDI note C1
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TrackRole
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrackRole {
+    Rhythm,
+    #[serde(rename = "lead")]
+    LeadMelody,
+    #[serde(rename = "counter")]
+    CounterMelody,
+    Bass,
+    Drum,
+    #[serde(rename = "pad")]
+    PadSustain,
+}
+
+// ---------------------------------------------------------------------------
+// Voicing
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Voicing {
+    Poly,
+    Mono,
+}
+
+// ---------------------------------------------------------------------------
+// Strum types
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StrumDirection {
+    Down,
+    Up,
+    Mute,
+    Ghost,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StrumHit {
+    /// Position within pattern in ticks.
+    pub tick_offset: u32,
+    pub direction: StrumDirection,
+    /// Velocity multiplier 0.0–1.0.
+    pub velocity_factor: f32,
+    /// Chord spread time in ms (0 = simultaneous).
+    pub stagger_ms: f32,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StrumPattern {
+    pub name: String,
+    pub hits: Vec<StrumHit>,
+    /// Pattern length in beats.
+    pub beats: u32,
+}
+
+// ---------------------------------------------------------------------------
+// NoteEvent / CcEvent
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NoteEvent {
+    /// Absolute tick position from pattern start (480 ticks/beat).
+    pub tick: u32,
+    /// MIDI note 0–127.
+    pub note: u8,
+    /// Velocity 0–127.
+    pub velocity: u8,
+    /// Duration in ticks.
+    pub duration: u32,
+    /// MIDI channel 0–15, matches track id.
+    pub channel: u8,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CcEvent {
+    pub tick: u32,
+    /// CC number, or 255 for pitch bend.
+    pub cc: u8,
+    /// 0–127 for CC, 0–16383 for pitch bend (8192 = center).
+    pub value: u16,
+    pub channel: u8,
+}
+
+// ---------------------------------------------------------------------------
+// Pattern
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Pattern {
+    pub events: Vec<NoteEvent>,
+    pub cc_events: Vec<CcEvent>,
+    /// Total length in ticks.
+    pub length_ticks: u32,
+    /// Bar count this pattern spans.
+    pub bars: u32,
+}
+
+impl Pattern {
+    pub fn empty(bars: u32) -> Self {
+        Self {
+            events: Vec::new(),
+            cc_events: Vec::new(),
+            length_ticks: bars * super::TICKS_PER_BAR,
+            bars,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Track
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Track {
+    /// 0–15, doubles as MIDI channel.
+    pub id: u8,
+    pub name: String,
+    pub role: TrackRole,
+    pub instrument: InstrumentType,
+    pub voicing: Voicing,
+    pub muted: bool,
+    pub solo: bool,
+    pub patterns: HashMap<SongPart, Pattern>,
+    pub automation: HashMap<SongPart, Vec<CcEvent>>,
+    pub active_parts: HashMap<SongPart, bool>,
+}
+
+// ---------------------------------------------------------------------------
+// Song
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Song {
+    pub title: String,
+    /// Beats per minute.
+    pub tempo: f64,
+    pub time_signature: (u8, u8),
+    pub rhythm_scale: Scale,
+    pub lead_scale: Scale,
+    /// Exactly 16 tracks (channels 0–15).
+    pub tracks: Vec<Track>,
+    /// Ordered song parts (may repeat, e.g. Verse appears twice).
+    pub structure: Vec<SongPart>,
+    pub progressions: HashMap<SongPart, Vec<ChordDegree>>,
+    pub strum_pattern: StrumPattern,
+    /// 0.0 = straight, 1.0 = full triplet swing.
+    pub swing: f32,
+}

--- a/src/engine/theory.rs
+++ b/src/engine/theory.rs
@@ -1,0 +1,620 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+// ---------------------------------------------------------------------------
+// PitchClass
+// ---------------------------------------------------------------------------
+
+/// The 12 pitch classes of Western music.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum PitchClass {
+    C = 0,
+    Cs = 1,
+    D = 2,
+    Ds = 3,
+    E = 4,
+    F = 5,
+    Fs = 6,
+    G = 7,
+    Gs = 8,
+    A = 9,
+    As = 10,
+    B = 11,
+}
+
+impl PitchClass {
+    /// All 12 pitch classes in chromatic order.
+    pub const ALL: [PitchClass; 12] = [
+        PitchClass::C,
+        PitchClass::Cs,
+        PitchClass::D,
+        PitchClass::Ds,
+        PitchClass::E,
+        PitchClass::F,
+        PitchClass::Fs,
+        PitchClass::G,
+        PitchClass::Gs,
+        PitchClass::A,
+        PitchClass::As,
+        PitchClass::B,
+    ];
+
+    /// Convert a MIDI note number to its pitch class.
+    pub fn from_midi(note: u8) -> Self {
+        PitchClass::ALL[(note % 12) as usize]
+    }
+
+    /// Semitone offset from C (0–11).
+    pub fn to_semitone(self) -> u8 {
+        self as u8
+    }
+
+    /// Transpose by a signed number of semitones.
+    pub fn transpose(self, semitones: i8) -> Self {
+        let val = (self.to_semitone() as i16 + semitones as i16).rem_euclid(12) as u8;
+        PitchClass::ALL[val as usize]
+    }
+}
+
+/// Display uses standard naming: C, C#, D, Eb, E, F, F#, G, Ab, A, Bb, B.
+impl fmt::Display for PitchClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            PitchClass::C => "C",
+            PitchClass::Cs => "C#",
+            PitchClass::D => "D",
+            PitchClass::Ds => "Eb",
+            PitchClass::E => "E",
+            PitchClass::F => "F",
+            PitchClass::Fs => "F#",
+            PitchClass::G => "G",
+            PitchClass::Gs => "Ab",
+            PitchClass::A => "A",
+            PitchClass::As => "Bb",
+            PitchClass::B => "B",
+        };
+        write!(f, "{name}")
+    }
+}
+
+impl FromStr for PitchClass {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "C" => Ok(PitchClass::C),
+            "C#" | "Db" => Ok(PitchClass::Cs),
+            "D" => Ok(PitchClass::D),
+            "D#" | "Eb" => Ok(PitchClass::Ds),
+            "E" => Ok(PitchClass::E),
+            "F" => Ok(PitchClass::F),
+            "F#" | "Gb" => Ok(PitchClass::Fs),
+            "G" => Ok(PitchClass::G),
+            "G#" | "Ab" => Ok(PitchClass::Gs),
+            "A" => Ok(PitchClass::A),
+            "A#" | "Bb" => Ok(PitchClass::As),
+            "B" => Ok(PitchClass::B),
+            _ => Err(anyhow::anyhow!("unknown pitch class: {s}")),
+        }
+    }
+}
+
+impl Serialize for PitchClass {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for PitchClass {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ScaleType
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScaleType {
+    Major,
+    NaturalMinor,
+    HarmonicMinor,
+    Dorian,
+    Mixolydian,
+    MinorPentatonic,
+    Blues,
+}
+
+impl ScaleType {
+    /// Semitone intervals from root for this scale.
+    pub fn intervals(self) -> &'static [u8] {
+        match self {
+            ScaleType::Major => &[0, 2, 4, 5, 7, 9, 11],
+            ScaleType::NaturalMinor => &[0, 2, 3, 5, 7, 8, 10],
+            ScaleType::HarmonicMinor => &[0, 2, 3, 5, 7, 8, 11],
+            ScaleType::Dorian => &[0, 2, 3, 5, 7, 9, 10],
+            ScaleType::Mixolydian => &[0, 2, 4, 5, 7, 9, 10],
+            ScaleType::MinorPentatonic => &[0, 3, 5, 7, 10],
+            ScaleType::Blues => &[0, 3, 5, 6, 7, 10],
+        }
+    }
+
+    /// For scales with fewer than 7 notes, return the parent diatonic intervals
+    /// used for chord derivation.
+    pub fn parent_diatonic_intervals(self) -> &'static [u8] {
+        match self {
+            ScaleType::MinorPentatonic | ScaleType::Blues => ScaleType::NaturalMinor.intervals(),
+            _ => self.intervals(),
+        }
+    }
+}
+
+impl FromStr for ScaleType {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().replace('-', "_").as_str() {
+            "major" => Ok(ScaleType::Major),
+            "natural_minor" | "minor" => Ok(ScaleType::NaturalMinor),
+            "harmonic_minor" => Ok(ScaleType::HarmonicMinor),
+            "dorian" => Ok(ScaleType::Dorian),
+            "mixolydian" => Ok(ScaleType::Mixolydian),
+            "minor_pentatonic" => Ok(ScaleType::MinorPentatonic),
+            "blues" => Ok(ScaleType::Blues),
+            _ => Err(anyhow::anyhow!("unknown scale type: {s}")),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scale
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Scale {
+    pub root: PitchClass,
+    pub scale_type: ScaleType,
+    /// Extra semitone offsets from root that can be toggled on.
+    pub passing_tones: Vec<u8>,
+    /// Per-degree toggle; index 0 (root) is always treated as enabled.
+    pub enabled_degrees: Vec<bool>,
+}
+
+impl Scale {
+    pub fn new(root: PitchClass, scale_type: ScaleType) -> Self {
+        let n = scale_type.intervals().len();
+        Self {
+            root,
+            scale_type,
+            passing_tones: Vec::new(),
+            enabled_degrees: vec![true; n],
+        }
+    }
+
+    /// Concrete pitch classes for the enabled degrees.
+    pub fn pitch_classes(&self) -> Vec<PitchClass> {
+        self.scale_type
+            .intervals()
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| self.enabled_degrees.get(*i).copied().unwrap_or(true))
+            .map(|(_, &interval)| self.root.transpose(interval as i8))
+            .collect()
+    }
+
+    /// Derive diatonic triads for each of the 7 scale degrees.
+    /// For pentatonic/blues, uses the parent diatonic scale.
+    pub fn diatonic_chords(&self) -> Vec<(ChordDegree, ChordQuality)> {
+        let intervals = self.scale_type.parent_diatonic_intervals();
+        if intervals.len() < 7 {
+            return Vec::new();
+        }
+
+        ChordDegree::ALL
+            .iter()
+            .enumerate()
+            .map(|(i, &degree)| {
+                let root = intervals[i] as i16;
+
+                let third = {
+                    let mut v = intervals[(i + 2) % 7] as i16;
+                    if v <= root {
+                        v += 12;
+                    }
+                    v
+                };
+                let fifth = {
+                    let mut v = intervals[(i + 4) % 7] as i16;
+                    if v <= root {
+                        v += 12;
+                    }
+                    v
+                };
+
+                let quality = match ((third - root) as u8, (fifth - root) as u8) {
+                    (4, 7) => ChordQuality::Major,
+                    (3, 7) => ChordQuality::Minor,
+                    (3, 6) => ChordQuality::Diminished,
+                    (4, 8) => ChordQuality::Augmented,
+                    _ => ChordQuality::Major,
+                };
+
+                (degree, quality)
+            })
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ChordQuality
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChordQuality {
+    Major,
+    Minor,
+    Diminished,
+    Augmented,
+    Sus2,
+    Sus4,
+    Major7,
+    Minor7,
+    Dominant7,
+    Add9,
+}
+
+impl ChordQuality {
+    /// Semitone offsets from root for this chord quality.
+    pub fn intervals(self) -> &'static [u8] {
+        match self {
+            ChordQuality::Major => &[0, 4, 7],
+            ChordQuality::Minor => &[0, 3, 7],
+            ChordQuality::Diminished => &[0, 3, 6],
+            ChordQuality::Augmented => &[0, 4, 8],
+            ChordQuality::Sus2 => &[0, 2, 7],
+            ChordQuality::Sus4 => &[0, 5, 7],
+            ChordQuality::Major7 => &[0, 4, 7, 11],
+            ChordQuality::Minor7 => &[0, 3, 7, 10],
+            ChordQuality::Dominant7 => &[0, 4, 7, 10],
+            ChordQuality::Add9 => &[0, 4, 7, 14],
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ChordDegree
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[allow(clippy::upper_case_acronyms)]
+pub enum ChordDegree {
+    I,
+    II,
+    III,
+    IV,
+    V,
+    VI,
+    VII,
+}
+
+impl ChordDegree {
+    pub const ALL: [ChordDegree; 7] = [
+        ChordDegree::I,
+        ChordDegree::II,
+        ChordDegree::III,
+        ChordDegree::IV,
+        ChordDegree::V,
+        ChordDegree::VI,
+        ChordDegree::VII,
+    ];
+
+    /// Zero-based index (I=0, VII=6).
+    pub fn to_index(self) -> usize {
+        self as usize
+    }
+}
+
+impl fmt::Display for ChordDegree {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            ChordDegree::I => "I",
+            ChordDegree::II => "II",
+            ChordDegree::III => "III",
+            ChordDegree::IV => "IV",
+            ChordDegree::V => "V",
+            ChordDegree::VI => "VI",
+            ChordDegree::VII => "VII",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl FromStr for ChordDegree {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_uppercase().as_str() {
+            "I" => Ok(ChordDegree::I),
+            "II" => Ok(ChordDegree::II),
+            "III" => Ok(ChordDegree::III),
+            "IV" => Ok(ChordDegree::IV),
+            "V" => Ok(ChordDegree::V),
+            "VI" => Ok(ChordDegree::VI),
+            "VII" => Ok(ChordDegree::VII),
+            _ => Err(anyhow::anyhow!("unknown chord degree: {s}")),
+        }
+    }
+}
+
+impl Serialize for ChordDegree {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for ChordDegree {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Chord
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Chord {
+    pub root: PitchClass,
+    pub quality: ChordQuality,
+    pub degree: ChordDegree,
+    /// 0 = root position, 1 = first inversion, 2 = second inversion.
+    pub inversion: u8,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- PitchClass --------------------------------------------------------
+
+    #[test]
+    fn pitch_class_from_midi() {
+        assert_eq!(PitchClass::from_midi(60), PitchClass::C); // Middle C
+        assert_eq!(PitchClass::from_midi(61), PitchClass::Cs);
+        assert_eq!(PitchClass::from_midi(69), PitchClass::A); // A440
+        assert_eq!(PitchClass::from_midi(0), PitchClass::C);
+        assert_eq!(PitchClass::from_midi(127), PitchClass::G); // 127 % 12 = 7
+    }
+
+    #[test]
+    fn pitch_class_to_semitone() {
+        assert_eq!(PitchClass::C.to_semitone(), 0);
+        assert_eq!(PitchClass::Fs.to_semitone(), 6);
+        assert_eq!(PitchClass::B.to_semitone(), 11);
+    }
+
+    #[test]
+    fn pitch_class_transpose() {
+        assert_eq!(PitchClass::C.transpose(4), PitchClass::E);
+        assert_eq!(PitchClass::C.transpose(7), PitchClass::G);
+        assert_eq!(PitchClass::G.transpose(5), PitchClass::C);
+        assert_eq!(PitchClass::A.transpose(-3), PitchClass::Fs);
+        assert_eq!(PitchClass::C.transpose(-1), PitchClass::B);
+        assert_eq!(PitchClass::C.transpose(12), PitchClass::C);
+        assert_eq!(PitchClass::C.transpose(-12), PitchClass::C);
+    }
+
+    #[test]
+    fn pitch_class_display() {
+        assert_eq!(PitchClass::As.to_string(), "Bb");
+        assert_eq!(PitchClass::Ds.to_string(), "Eb");
+        assert_eq!(PitchClass::Gs.to_string(), "Ab");
+        assert_eq!(PitchClass::Cs.to_string(), "C#");
+        assert_eq!(PitchClass::Fs.to_string(), "F#");
+    }
+
+    #[test]
+    fn pitch_class_from_str() {
+        assert_eq!("Bb".parse::<PitchClass>().unwrap(), PitchClass::As);
+        assert_eq!("A#".parse::<PitchClass>().unwrap(), PitchClass::As);
+        assert_eq!("C#".parse::<PitchClass>().unwrap(), PitchClass::Cs);
+        assert_eq!("Db".parse::<PitchClass>().unwrap(), PitchClass::Cs);
+        assert!("X".parse::<PitchClass>().is_err());
+    }
+
+    #[test]
+    fn pitch_class_serde_roundtrip() {
+        let pc = PitchClass::As;
+        let json = serde_json::to_string(&pc).unwrap();
+        assert_eq!(json, r#""Bb""#);
+        let parsed: PitchClass = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, pc);
+    }
+
+    // -- Scale construction ------------------------------------------------
+
+    #[test]
+    fn c_major_scale_notes() {
+        let scale = Scale::new(PitchClass::C, ScaleType::Major);
+        let notes = scale.pitch_classes();
+        assert_eq!(
+            notes,
+            vec![
+                PitchClass::C,
+                PitchClass::D,
+                PitchClass::E,
+                PitchClass::F,
+                PitchClass::G,
+                PitchClass::A,
+                PitchClass::B,
+            ]
+        );
+    }
+
+    #[test]
+    fn g_natural_minor_scale_notes() {
+        let scale = Scale::new(PitchClass::G, ScaleType::NaturalMinor);
+        let notes = scale.pitch_classes();
+        assert_eq!(
+            notes,
+            vec![
+                PitchClass::G,
+                PitchClass::A,
+                PitchClass::As, // Bb
+                PitchClass::C,
+                PitchClass::D,
+                PitchClass::Ds, // Eb
+                PitchClass::F,
+            ]
+        );
+    }
+
+    #[test]
+    fn bb_major_scale_notes() {
+        let scale = Scale::new(PitchClass::As, ScaleType::Major);
+        let notes = scale.pitch_classes();
+        assert_eq!(
+            notes,
+            vec![
+                PitchClass::As, // Bb
+                PitchClass::C,
+                PitchClass::D,
+                PitchClass::Ds, // Eb
+                PitchClass::F,
+                PitchClass::G,
+                PitchClass::A,
+            ]
+        );
+    }
+
+    #[test]
+    fn g_minor_pentatonic_notes() {
+        let scale = Scale::new(PitchClass::G, ScaleType::MinorPentatonic);
+        let notes = scale.pitch_classes();
+        assert_eq!(
+            notes,
+            vec![
+                PitchClass::G,
+                PitchClass::As, // Bb
+                PitchClass::C,
+                PitchClass::D,
+                PitchClass::F,
+            ]
+        );
+    }
+
+    #[test]
+    fn scale_with_disabled_degrees() {
+        let mut scale = Scale::new(PitchClass::C, ScaleType::Major);
+        scale.enabled_degrees[3] = false; // disable 4th degree (F)
+        let notes = scale.pitch_classes();
+        assert_eq!(
+            notes,
+            vec![
+                PitchClass::C,
+                PitchClass::D,
+                PitchClass::E,
+                // F is disabled
+                PitchClass::G,
+                PitchClass::A,
+                PitchClass::B,
+            ]
+        );
+    }
+
+    // -- Diatonic chord derivation -----------------------------------------
+
+    #[test]
+    fn c_major_diatonic_chords() {
+        let scale = Scale::new(PitchClass::C, ScaleType::Major);
+        let chords = scale.diatonic_chords();
+        let qualities: Vec<ChordQuality> = chords.iter().map(|(_, q)| *q).collect();
+        assert_eq!(
+            qualities,
+            vec![
+                ChordQuality::Major,      // I
+                ChordQuality::Minor,      // ii
+                ChordQuality::Minor,      // iii
+                ChordQuality::Major,      // IV
+                ChordQuality::Major,      // V
+                ChordQuality::Minor,      // vi
+                ChordQuality::Diminished, // vii
+            ]
+        );
+    }
+
+    #[test]
+    fn a_natural_minor_diatonic_chords() {
+        let scale = Scale::new(PitchClass::A, ScaleType::NaturalMinor);
+        let chords = scale.diatonic_chords();
+        let qualities: Vec<ChordQuality> = chords.iter().map(|(_, q)| *q).collect();
+        assert_eq!(
+            qualities,
+            vec![
+                ChordQuality::Minor,      // i
+                ChordQuality::Diminished, // ii
+                ChordQuality::Major,      // III
+                ChordQuality::Minor,      // iv
+                ChordQuality::Minor,      // v
+                ChordQuality::Major,      // VI
+                ChordQuality::Major,      // VII
+            ]
+        );
+    }
+
+    #[test]
+    fn minor_pentatonic_derives_from_natural_minor() {
+        let pent = Scale::new(PitchClass::G, ScaleType::MinorPentatonic);
+        let minor = Scale::new(PitchClass::G, ScaleType::NaturalMinor);
+        assert_eq!(pent.diatonic_chords(), minor.diatonic_chords());
+    }
+
+    // -- ChordQuality intervals --------------------------------------------
+
+    #[test]
+    fn chord_quality_intervals() {
+        assert_eq!(ChordQuality::Major.intervals(), &[0, 4, 7]);
+        assert_eq!(ChordQuality::Minor.intervals(), &[0, 3, 7]);
+        assert_eq!(ChordQuality::Diminished.intervals(), &[0, 3, 6]);
+        assert_eq!(ChordQuality::Dominant7.intervals(), &[0, 4, 7, 10]);
+    }
+
+    // -- ChordDegree -------------------------------------------------------
+
+    #[test]
+    fn chord_degree_index() {
+        assert_eq!(ChordDegree::I.to_index(), 0);
+        assert_eq!(ChordDegree::IV.to_index(), 3);
+        assert_eq!(ChordDegree::VII.to_index(), 6);
+    }
+
+    #[test]
+    fn chord_degree_serde_roundtrip() {
+        let deg = ChordDegree::IV;
+        let json = serde_json::to_string(&deg).unwrap();
+        assert_eq!(json, r#""IV""#);
+        let parsed: ChordDegree = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, deg);
+    }
+
+    // -- Scale serde -------------------------------------------------------
+
+    #[test]
+    fn scale_serde_roundtrip() {
+        let scale = Scale::new(PitchClass::As, ScaleType::Major);
+        let json = serde_json::to_string(&scale).unwrap();
+        let parsed: Scale = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, scale);
+    }
+}

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -1,0 +1,2 @@
+// Iced Application impl — GUI entry point.
+// Implementation will follow in a future issue.

--- a/src/gui/header.rs
+++ b/src/gui/header.rs
@@ -1,0 +1,2 @@
+// Transport bar, scale selectors, song structure.
+// Implementation will follow in a future issue.

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1,0 +1,14 @@
+pub mod app;
+pub mod header;
+pub mod pattern_view;
+pub mod theme;
+pub mod tracks;
+pub mod widgets;
+
+use anyhow::Result;
+
+/// Launch the GUI application.
+pub fn run() -> Result<()> {
+    tracing::info!("GUI mode — not yet implemented");
+    Ok(())
+}

--- a/src/gui/pattern_view.rs
+++ b/src/gui/pattern_view.rs
@@ -1,0 +1,2 @@
+// Canvas widget: piano-roll-style pattern visualization.
+// Implementation will follow in a future issue.

--- a/src/gui/theme.rs
+++ b/src/gui/theme.rs
@@ -1,0 +1,2 @@
+// Dark theme, colors, and fonts.
+// Implementation will follow in a future issue.

--- a/src/gui/tracks.rs
+++ b/src/gui/tracks.rs
@@ -1,0 +1,2 @@
+// Track list panel.
+// Implementation will follow in a future issue.

--- a/src/gui/widgets.rs
+++ b/src/gui/widgets.rs
@@ -1,0 +1,2 @@
+// Custom widgets: scale grid, chord display, etc.
+// Implementation will follow in a future issue.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,22 @@
+#![allow(dead_code)]
+
+use anyhow::Result;
+use clap::Parser;
+
+mod bridge;
+mod cli;
+mod engine;
+mod gui;
+mod midi_export;
+mod state;
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let args = cli::Cli::parse();
+
+    match &args.command {
+        Some(cmd) => cli::commands::execute(cmd, &args),
+        None => gui::run(),
+    }
+}

--- a/src/midi_export.rs
+++ b/src/midi_export.rs
@@ -1,0 +1,51 @@
+// MIDI file writing via midly.
+// Implementation will follow in a future issue.
+
+#[cfg(test)]
+mod tests {
+    use midly::num::{u15, u28, u4, u7};
+    use midly::{Format, Header, MidiMessage, Smf, Timing, TrackEvent, TrackEventKind};
+
+    #[test]
+    fn midi_write_read_roundtrip() {
+        let mut smf = Smf::new(Header::new(
+            Format::Parallel,
+            Timing::Metrical(u15::new(480)),
+        ));
+
+        let track = vec![
+            TrackEvent {
+                delta: u28::new(0),
+                kind: TrackEventKind::Midi {
+                    channel: u4::new(0),
+                    message: MidiMessage::NoteOn {
+                        key: u7::new(60),
+                        vel: u7::new(100),
+                    },
+                },
+            },
+            TrackEvent {
+                delta: u28::new(480),
+                kind: TrackEventKind::Midi {
+                    channel: u4::new(0),
+                    message: MidiMessage::NoteOff {
+                        key: u7::new(60),
+                        vel: u7::new(0),
+                    },
+                },
+            },
+            TrackEvent {
+                delta: u28::new(0),
+                kind: TrackEventKind::Meta(midly::MetaMessage::EndOfTrack),
+            },
+        ];
+        smf.tracks.push(track);
+
+        let mut buf = Vec::new();
+        smf.write_std(&mut buf).unwrap();
+
+        let parsed = Smf::parse(&buf).unwrap();
+        assert_eq!(parsed.tracks.len(), 1);
+        assert_eq!(parsed.tracks[0].len(), 3);
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,31 @@
+use serde::{Deserialize, Serialize};
+
+use crate::engine::composer::Composer;
+use crate::engine::song::Song;
+
+/// An immutable snapshot of the song state for undo/redo.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Snapshot {
+    pub song: Song,
+    pub seed: u64,
+    pub label: String,
+    /// Unix timestamp in milliseconds.
+    pub timestamp: u64,
+}
+
+/// Shared application state.
+/// Wrapped in `Arc<Mutex<AppState>>` for cross-thread access.
+pub struct AppState {
+    pub song: Song,
+    pub composer: Composer,
+    pub history: Vec<Snapshot>,
+    pub history_index: usize,
+    pub is_playing: bool,
+    pub tempo: f64,
+    pub beat_position: f64,
+    pub bar_position: u32,
+    pub bitwig_connected: bool,
+    pub selected_track: usize,
+    pub selected_part_index: usize,
+    pub seed_counter: u64,
+}


### PR DESCRIPTION
## Summary

- **Cargo.toml** with all dependencies: clap, tokio, midly, serde, rand, tracing, anyhow
- **engine/theory.rs**: `PitchClass`, `ScaleType`, `Scale`, `ChordQuality`, `ChordDegree`, `Chord` with full implementations (from_midi, transpose, diatonic chord derivation, serde round-trip)
- **engine/song.rs**: `SongPart`, `InstrumentType`, `TrackRole`, `Voicing`, `NoteEvent`, `CcEvent`, `Pattern`, `Track`, `Song`, `StrumPattern` with serde derives and helper methods
- **engine/composer.rs**: `Composer` struct with deterministic seed
- **cli/mod.rs**: Complete clap subcommand definitions (46 commands matching CLI spec)
- **cli/commands.rs**: Stub execute dispatcher returning JSON
- **gui/, bridge/, midi_export.rs, state.rs**: Module stubs matching KICKOFF.md file layout
- **27 tests**: pitch class math, scale construction, diatonic chord derivation, pattern determinism, CLI parsing, MIDI file round-trip

Closes #1

## Test plan

- [x] `cargo build --release` succeeds
- [x] `cargo test` — 27 tests pass
- [x] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)