### PR TITLE
feat: update rand and rand_chacha to 0.10 (closes #20)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ description = "Folk/indie/alt-country MIDI composition engine"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 midly = "0.5"
-rand = "0.8"
-rand_chacha = "0.3"
+rand = "0.10"
+rand_chacha = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/src/engine/composer.rs
+++ b/src/engine/composer.rs
@@ -19,7 +19,7 @@ impl Composer {
 
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
+    use rand::RngExt;
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
 
@@ -28,8 +28,8 @@ mod tests {
         let mut rng1 = ChaCha8Rng::seed_from_u64(42);
         let mut rng2 = ChaCha8Rng::seed_from_u64(42);
 
-        let notes1: Vec<u8> = (0..32).map(|_| rng1.gen_range(40..80)).collect();
-        let notes2: Vec<u8> = (0..32).map(|_| rng2.gen_range(40..80)).collect();
+        let notes1: Vec<u8> = (0..32).map(|_| rng1.random_range(40..80)).collect();
+        let notes2: Vec<u8> = (0..32).map(|_| rng2.random_range(40..80)).collect();
 
         assert_eq!(notes1, notes2, "same seed must produce identical output");
     }
@@ -39,8 +39,8 @@ mod tests {
         let mut rng1 = ChaCha8Rng::seed_from_u64(42);
         let mut rng2 = ChaCha8Rng::seed_from_u64(99);
 
-        let notes1: Vec<u8> = (0..32).map(|_| rng1.gen_range(40..80)).collect();
-        let notes2: Vec<u8> = (0..32).map(|_| rng2.gen_range(40..80)).collect();
+        let notes1: Vec<u8> = (0..32).map(|_| rng1.random_range(40..80)).collect();
+        let notes2: Vec<u8> = (0..32).map(|_| rng2.random_range(40..80)).collect();
 
         assert_ne!(notes1, notes2, "different seeds should differ");
     }


### PR DESCRIPTION
## Summary

- Update `rand` from 0.8 to 0.10 and `rand_chacha` from 0.3 to 0.10
- Migrate API: `Rng::gen_range()` → `RngExt::random_range()`
- Deterministic seed guarantee preserved — all 64 tests pass, clippy clean

## Why Now

Current codebase usage is minimal (only `composer.rs` tests). Migration cost will grow as engine modules (#4–#9) are implemented, all of which will use `rand` heavily for deterministic composition.

## Test plan

- [x] `cargo build --release` succeeds
- [x] `cargo test` — all 64 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Seed determinism tests still pass (`same_seed_produces_same_output`, `different_seeds_produce_different_output`)

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)