### PR TITLE
fix: correct V chord quality for natural minor in THEORY.md

### DIFF
--- a/docs/engine/THEORY.md
+++ b/docs/engine/THEORY.md
@@ -10,7 +10,7 @@ Given a 7-note scale, stack every other note to build triads on each degree:
 | II | Minor | Diminished |
 | III | Minor | Major |
 | IV | Major | Minor |
-| V | Major | Major |
+| V | Major | Minor |
 | VI | Minor | Major |
 | VII | Diminished | Major |
 


### PR DESCRIPTION
## Summary

- Fixes the diatonic chord table in `docs/engine/THEORY.md`: V chord under Natural Minor changed from **Major** to **Minor**
- Natural minor formula is i-ii°-III-iv-**v**-VI-VII — the V chord is minor (e.g. in A minor: E-G-B = Em)
- The existing code in `theory.rs` already computes this correctly (confirmed by `a_natural_minor_diatonic_chords` test)

Closes #21

## Test plan

- [x] `cargo test` — 64 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo build --release` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)