### PR TITLE
fix: correct total bar count in DEFAULTS.md (60 → 64)

### DIFF
--- a/docs/reference/DEFAULTS.md
+++ b/docs/reference/DEFAULTS.md
@@ -15,7 +15,7 @@
 
 Intro → Verse → PreChorus → Chorus → Verse → PreChorus → Chorus → Bridge → Chorus → Outro
 
-Total: 60 bars (4+8+4+8+8+4+8+8+8+4, second verse/prechorus/chorus same bar counts)
+Total: 64 bars (4+8+4+8+8+4+8+8+8+4, second verse/prechorus/chorus same bar counts)
 
 ## Default Chord Progressions
 


### PR DESCRIPTION
## Summary
- Fixes the total bar count in `docs/reference/DEFAULTS.md` from 60 to 64
- The section structure (4+8+4+8+8+4+8+8+8+4) correctly sums to 64 bars, not 60
- No other docs reference the incorrect 60-bar count

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)