### PR TITLE
fix: update rand/rand_chacha version in KICKOFF.md to 0.10 (closes #35)

### DIFF
--- a/docs/KICKOFF.md
+++ b/docs/KICKOFF.md
@@ -30,7 +30,7 @@ The user never inputs individual notes through the GUI. They press "next suggest
 | Async runtime | tokio | 1.50.0 | MIT |
 | MIDI files | midly | 0.5.3 | MIT |
 | Serialization | serde + serde_json | 1.x | MIT/Apache |
-| RNG | rand + rand_chacha | 0.8 / 0.3 | MIT/Apache |
+| RNG | rand + rand_chacha | 0.10 / 0.10 | MIT/Apache |
 | Logging | tracing + tracing-subscriber | 0.1 / 0.3 | MIT |
 | Bitwig ext | Java 12+ | API 18 | — |
 | Bitwig build | Maven | 3.x | — |


### PR DESCRIPTION
## Summary
- Updates the technology stack table in `docs/KICKOFF.md` to reflect `rand 0.10 / rand_chacha 0.10` (was `0.8 / 0.3`)
- Aligns documentation with the dependency update merged in PR #30 (issue #20)
- Verified versions match `Cargo.toml`

Closes #35

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo test` passes (64 tests)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)