### PR TITLE
fix: reconcile dynamics scaling values in RHYTHM.md (closes #25)

### DIFF
--- a/docs/engine/RHYTHM.md
+++ b/docs/engine/RHYTHM.md
@@ -97,7 +97,7 @@ Downbeats (tick % 1920 == 0) get tighter humanization (÷2).
 ```
 base_variation = random_gauss(mean=0, std_dev=6)
 accent_curve: beat 1 = +10, beat 3 = +5, offbeats = -5
-part_dynamics: intro=0.6, verse=0.75, prechorus=0.85, chorus=1.0, bridge=0.7, outro=0.55
+part_dynamics: intro=0.55, verse=0.70, prechorus=0.82, chorus=1.0, bridge=0.65, outro=0.50
 final_velocity = clamp(base_vel + base_variation + accent_curve) × part_dynamics
 ```
 


### PR DESCRIPTION
## Summary
- Updated `docs/engine/RHYTHM.md` part_dynamics values to match `docs/engine/ARRANGEMENT.md` and `docs/reference/DEFAULTS.md`
- Changed: intro 0.60→0.55, verse 0.75→0.70, prechorus 0.85→0.82, bridge 0.70→0.65, outro 0.55→0.50
- Chorus (1.00) was already consistent across all three files

Closes #25

## Test plan
- [x] Verify RHYTHM.md values now match ARRANGEMENT.md
- [x] Verify RHYTHM.md values now match DEFAULTS.md
- [x] Confirm chorus value (1.00) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)