### PR TITLE
fix: map percussion instruments to correct GM drum notes

### DIFF
--- a/docs/architecture/DATA_MODEL.md
+++ b/docs/architecture/DATA_MODEL.md
@@ -60,7 +60,22 @@ Each has `midi_range() -> (u8, u8)` for comfortable playing range.
 
 **Percussion:** Kick, Snare, HiHat, OpenHiHat, Clap, Tambourine, Cowbell, Shaker, RideCymbal, CrashCymbal, Toms, Rimshot
 
-All percussion sends fixed MIDI note 36 (C1). One instrument per track.
+Each percussion instrument maps to its General MIDI drum note. One instrument per track.
+
+| Instrument | GM Note | GM Name |
+|---|---|---|
+| Kick | 36 | Acoustic Bass Drum |
+| Snare | 38 | Acoustic Snare |
+| HiHat | 42 | Closed Hi-Hat |
+| OpenHiHat | 46 | Open Hi-Hat |
+| Clap | 39 | Hand Clap |
+| Tambourine | 54 | Tambourine |
+| Cowbell | 56 | Cowbell |
+| Shaker | 70 | Maracas |
+| RideCymbal | 51 | Ride Cymbal 1 |
+| CrashCymbal | 49 | Crash Cymbal 1 |
+| Toms | 45 | Low Tom |
+| Rimshot | 37 | Side Stick |
 
 ### TrackRole
 Enum: Rhythm, LeadMelody, CounterMelody, Bass, Drum, PadSustain
@@ -173,5 +188,5 @@ All types derive `Serialize, Deserialize`. JSON is the interchange format for CL
 - Ticks per beat: 480
 - Ticks per bar (4/4): 1920
 - Middle C (C3 in Bitwig): MIDI 60
-- Drum note for single-instrument tracks: MIDI 36 (C1)
+- Drum notes: per-instrument GM mapping (see InstrumentType table above)
 - Pitch bend center: 8192

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -13,7 +13,5 @@ pub const TICKS_PER_BEAT: u32 = 480;
 pub const TICKS_PER_BAR: u32 = 1920;
 /// MIDI note number for Middle C (C3 in Bitwig).
 pub const MIDDLE_C: u8 = 60;
-/// MIDI note for single-instrument percussion tracks.
-pub const DRUM_NOTE: u8 = 36;
 /// Pitch bend center value.
 pub const PITCH_BEND_CENTER: u16 = 8192;

--- a/src/engine/song.rs
+++ b/src/engine/song.rs
@@ -103,9 +103,32 @@ impl InstrumentType {
         )
     }
 
+    /// General MIDI drum note for percussion instruments.
+    /// Returns `None` for melodic instruments.
+    pub fn gm_drum_note(self) -> Option<u8> {
+        match self {
+            InstrumentType::Kick => Some(36),        // Acoustic Bass Drum
+            InstrumentType::Snare => Some(38),       // Acoustic Snare
+            InstrumentType::HiHat => Some(42),       // Closed Hi-Hat
+            InstrumentType::OpenHiHat => Some(46),   // Open Hi-Hat
+            InstrumentType::Clap => Some(39),        // Hand Clap
+            InstrumentType::Tambourine => Some(54),  // Tambourine
+            InstrumentType::Cowbell => Some(56),      // Cowbell
+            InstrumentType::Shaker => Some(70),      // Maracas
+            InstrumentType::RideCymbal => Some(51),  // Ride Cymbal 1
+            InstrumentType::CrashCymbal => Some(49), // Crash Cymbal 1
+            InstrumentType::Toms => Some(45),        // Low Tom
+            InstrumentType::Rimshot => Some(37),     // Side Stick
+            _ => None,
+        }
+    }
+
     /// Comfortable MIDI note range (low, high) for melodic instruments.
-    /// Returns `(36, 36)` for percussion (fixed MIDI note C1).
+    /// For percussion, returns `(note, note)` with the GM drum note.
     pub fn midi_range(self) -> (u8, u8) {
+        if let Some(note) = self.gm_drum_note() {
+            return (note, note);
+        }
         match self {
             InstrumentType::AcousticGuitar => (40, 79),
             InstrumentType::ElectricGuitar => (40, 84),
@@ -117,7 +140,7 @@ impl InstrumentType {
             InstrumentType::HammondOrgan => (36, 84),
             InstrumentType::Piano => (28, 96),
             InstrumentType::Pad => (36, 84),
-            _ => (36, 36), // percussion: fixed MIDI note C1
+            _ => unreachable!("all percussion handled by gm_drum_note"),
         }
     }
 }
@@ -498,7 +521,45 @@ mod tests {
     fn instrument_type_midi_range() {
         assert_eq!(InstrumentType::AcousticGuitar.midi_range(), (40, 79));
         assert_eq!(InstrumentType::ElectricBass.midi_range(), (28, 55));
+        // Percussion instruments return their specific GM drum note
         assert_eq!(InstrumentType::Kick.midi_range(), (36, 36));
+        assert_eq!(InstrumentType::Snare.midi_range(), (38, 38));
+        assert_eq!(InstrumentType::HiHat.midi_range(), (42, 42));
+    }
+
+    #[test]
+    fn percussion_gm_drum_note_mapping() {
+        // Each percussion instrument maps to its correct GM drum note
+        assert_eq!(InstrumentType::Kick.gm_drum_note(), Some(36));
+        assert_eq!(InstrumentType::Snare.gm_drum_note(), Some(38));
+        assert_eq!(InstrumentType::HiHat.gm_drum_note(), Some(42));
+        assert_eq!(InstrumentType::OpenHiHat.gm_drum_note(), Some(46));
+        assert_eq!(InstrumentType::Clap.gm_drum_note(), Some(39));
+        assert_eq!(InstrumentType::Tambourine.gm_drum_note(), Some(54));
+        assert_eq!(InstrumentType::Cowbell.gm_drum_note(), Some(56));
+        assert_eq!(InstrumentType::Shaker.gm_drum_note(), Some(70));
+        assert_eq!(InstrumentType::RideCymbal.gm_drum_note(), Some(51));
+        assert_eq!(InstrumentType::CrashCymbal.gm_drum_note(), Some(49));
+        assert_eq!(InstrumentType::Toms.gm_drum_note(), Some(45));
+        assert_eq!(InstrumentType::Rimshot.gm_drum_note(), Some(37));
+        // Melodic instruments return None
+        assert_eq!(InstrumentType::AcousticGuitar.gm_drum_note(), None);
+        assert_eq!(InstrumentType::Piano.gm_drum_note(), None);
+    }
+
+    #[test]
+    fn percussion_instruments_have_unique_notes() {
+        let percussion = [
+            InstrumentType::Kick, InstrumentType::Snare, InstrumentType::HiHat,
+            InstrumentType::OpenHiHat, InstrumentType::Clap, InstrumentType::Tambourine,
+            InstrumentType::Cowbell, InstrumentType::Shaker, InstrumentType::RideCymbal,
+            InstrumentType::CrashCymbal, InstrumentType::Toms, InstrumentType::Rimshot,
+        ];
+        let mut notes: Vec<u8> = percussion.iter().map(|i| i.gm_drum_note().unwrap()).collect();
+        let len_before = notes.len();
+        notes.sort();
+        notes.dedup();
+        assert_eq!(notes.len(), len_before, "all percussion instruments must have unique GM notes");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace the single `DRUM_NOTE=36` constant with per-instrument General MIDI drum note mapping
- Add `InstrumentType::gm_drum_note()` method returning the correct GM note for each of the 12 percussion variants (Kick=36, Snare=38, HiHat=42, OpenHiHat=46, Clap=39, Tambourine=54, Cowbell=56, Shaker=70, RideCymbal=51, CrashCymbal=49, Toms=45, Rimshot=37)
- Update `midi_range()` to use per-instrument notes instead of the `(36, 36)` catchall
- Update `DATA_MODEL.md` with the full GM drum note mapping table

Closes #48

## Test plan
- [x] Unit test verifying each percussion instrument maps to expected GM note
- [x] Unit test verifying all percussion notes are unique
- [x] Existing `midi_range()` test updated for new per-instrument values
- [x] All 92 tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo build --release` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)