### PR TITLE
fix: prevent i32 overflow in humanize() tick adjustment (closes #46)

### DIFF
--- a/src/engine/rhythm.rs
+++ b/src/engine/rhythm.rs
@@ -934,11 +934,7 @@ mod tests {
         engine.humanize(&mut events, TrackRole::Rhythm, SongPart::Chorus);
 
         // Tick should remain close to the original (within timing_max_offset=15)
-        let diff = if events[0].tick > large_tick {
-            events[0].tick - large_tick
-        } else {
-            large_tick - events[0].tick
-        };
+        let diff = events[0].tick.abs_diff(large_tick);
         assert!(
             diff <= 15,
             "tick drifted {} from original, expected <= 15",


### PR DESCRIPTION
## Summary
- Widened tick arithmetic in `humanize()` from `i32` to `i64` so tick values above `i32::MAX` (~2.1B) no longer silently wrap
- Result clamped to `[0, u32::MAX]` before storing back — no change to musical output for normal tick values
- Added tests for large-tick overflow safety and zero-tick underflow safety

## Test plan
- [x] `cargo build --release` — compiles clean
- [x] `cargo test` — 94 tests pass (including 2 new overflow/underflow tests)
- [x] `cargo clippy -- -D warnings` — no warnings

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)