### PR TITLE
build: bump version to 0.1.0 — core types complete

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "copper-hollow"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 description = "Folk/indie/alt-country MIDI composition engine"
 


### PR DESCRIPTION
## Summary
- Bumps `Cargo.toml` version from `0.0.1` to `0.1.0`
- Creates git tag `v0.1.0` marking core types milestone
- Per CLAUDE.md tagging scheme: v0.1.0 = core types complete (issues #2, #3 merged)

Closes #28

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo test` — 94 tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] Tag `v0.1.0` pushed to origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)