### PR TITLE
feat: bump Cargo.toml version to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "copper-hollow"
-version = "0.0.1"
+version = "0.3.0"
 edition = "2021"
 description = "Folk/indie/alt-country MIDI composition engine"
 


### PR DESCRIPTION
## Summary
- Bumps `Cargo.toml` version from `0.0.1` to `0.3.0`
- Resolves version inconsistency: tags v0.1.0 and v0.2.0 already exist, and all core engine modules (melody, drums, bass, arrangement, pads, composer orchestrator) are complete
- Aligns with CLAUDE.md tagging plan where v0.3.0 = CLI working

Closes #70

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo test` — 260 tests pass
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)