### PR TITLE
fix: update tokio minimum to 1.44.2 for RUSTSEC-2025-0023 (closes #67)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ rand = "0.10"
 rand_chacha = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.44.2", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
## Summary
- Set minimum tokio version requirement from `"1"` to `"1.44.2"` in Cargo.toml to address broadcast channel unsoundness advisory RUSTSEC-2025-0023
- Lockfile already pins tokio 1.50.0 (well past the fix); this change prevents future lockfile regenerations from selecting a vulnerable version
- `cargo audit` confirms zero vulnerabilities

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo test` passes (260 tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo audit` reports no vulnerabilities

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)