### PR TITLE
fix: set minimum tracing-subscriber version to 0.3.20 for RUSTSEC-2025-0055

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1.44.2", features = ["full"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }


### PR DESCRIPTION
## Summary
- Sets minimum `tracing-subscriber` version to `0.3.20` in `Cargo.toml` to ensure the ANSI escape injection fix (RUSTSEC-2025-0055) is always resolved
- Follows the same pattern as PR #76 which pinned `tokio` for RUSTSEC-2025-0023

Closes #68

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo test` — all 260 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo audit` — no advisories

🤖 Generated with [Claude Code](https://claude.com/claude-code)