### PR TITLE
fix: create missing v0.3.0 git tag and sync Cargo.lock (closes #82)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "copper-hollow"
-version = "0.0.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
## Summary
- Created annotated git tag `v0.3.0` on commit `12ffade` (CLI working milestone per CLAUDE.md)
- Tag pushed to remote origin
- Synced `Cargo.lock` version from `0.0.1` to `0.3.0` to match `Cargo.toml`

Closes #82

## Verification
- `git tag -l` now shows: v0.0.0, v0.0.1, v0.1.0, v0.2.0, **v0.3.0**
- `cargo build --release` — clean
- `cargo test` — 270 passed
- `cargo clippy -- -D warnings` — clean

## Test plan
- [x] `git tag -l` includes v0.3.0
- [x] `git show v0.3.0` points to commit 12ffade
- [x] Cargo.lock version matches Cargo.toml (0.3.0)
- [x] All 270 tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)