### PR TITLE
fix: remove global #![allow(dead_code)] and add targeted annotations (closes #84)

### DIFF
--- a/src/engine/arrangement.rs
+++ b/src/engine/arrangement.rs
@@ -4,6 +4,8 @@
 // to concrete Chord structs per bar, computes section tick ranges with occurrence-
 // based seed offsets, generates transition events (crash cymbals, open hi-hat,
 // velocity boosts) at section boundaries.
+// Fully implemented — awaiting GUI integration (v0.4.0).
+#![allow(dead_code)]
 
 use serde::{Deserialize, Serialize};
 

--- a/src/engine/bass.rs
+++ b/src/engine/bass.rs
@@ -1,5 +1,7 @@
 // Bass line generation: walking, root-fifth, pedal, octave patterns with
 // approach notes, voice leading, and register management per docs/engine/BASS.md.
+// Fully implemented — awaiting GUI integration (v0.4.0).
+#![allow(dead_code)]
 
 use rand::RngExt;
 use rand::SeedableRng;

--- a/src/engine/composer.rs
+++ b/src/engine/composer.rs
@@ -3,6 +3,8 @@
 // Ties all engine modules together: arrangement, drums, bass, melody, pads,
 // and rhythm. Produces a complete Song with patterns for every active track
 // in every section. Fully deterministic given the same seed + settings.
+// Fully implemented — awaiting GUI integration (v0.4.0).
+#![allow(dead_code)]
 
 use serde::{Deserialize, Serialize};
 

--- a/src/engine/drums.rs
+++ b/src/engine/drums.rs
@@ -1,6 +1,8 @@
 // Per-instrument drum pattern generation by song part.
 // Generates kick, snare, hi-hat, tambourine, shaker, cowbell, ride, and crash
 // patterns following genre-appropriate folk/indie grooves per docs/engine/DRUMS.md.
+// Fully implemented — awaiting GUI integration (v0.4.0).
+#![allow(dead_code)]
 
 use rand::RngExt;
 use rand::SeedableRng;

--- a/src/engine/melody.rs
+++ b/src/engine/melody.rs
@@ -1,4 +1,6 @@
 // Melodic contour generation, chord tone targeting, voice leading.
+// Fully implemented — awaiting GUI integration (v0.4.0).
+#![allow(dead_code)]
 
 use rand::RngExt;
 use rand::SeedableRng;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -9,10 +9,14 @@ pub mod song;
 pub mod theory;
 
 /// MIDI ticks per beat (quarter note).
+#[allow(dead_code)]
 pub const TICKS_PER_BEAT: u32 = 480;
 /// MIDI ticks per bar in 4/4 time.
+#[allow(dead_code)]
 pub const TICKS_PER_BAR: u32 = 1920;
 /// MIDI note number for Middle C (C3 in Bitwig).
+#[allow(dead_code)]
 pub const MIDDLE_C: u8 = 60;
 /// Pitch bend center value.
+#[allow(dead_code)]
 pub const PITCH_BEND_CENTER: u16 = 8192;

--- a/src/engine/pads.rs
+++ b/src/engine/pads.rs
@@ -1,5 +1,7 @@
 // Pad/sustain chord generation: voice-led sustained chords with open, close,
 // and drop-2 voicings per docs/engine/THEORY.md.
+// Fully implemented — awaiting GUI integration (v0.4.0).
+#![allow(dead_code)]
 
 use rand::RngExt;
 use rand::SeedableRng;

--- a/src/engine/rhythm.rs
+++ b/src/engine/rhythm.rs
@@ -1,4 +1,6 @@
 // Groove patterns, strum generation, humanization, and swing.
+// Fully implemented — awaiting GUI integration (v0.4.0).
+#![allow(dead_code)]
 
 use rand::RngExt;
 use rand::SeedableRng;

--- a/src/engine/song.rs
+++ b/src/engine/song.rs
@@ -22,6 +22,7 @@ pub enum SongPart {
 
 impl SongPart {
     /// Default bar count for this part.
+    #[allow(dead_code)]
     pub fn typical_bars(self) -> u32 {
         match self {
             SongPart::Intro => 4,
@@ -85,6 +86,7 @@ pub enum InstrumentType {
 
 impl InstrumentType {
     /// Whether this is a percussion instrument.
+    #[allow(dead_code)]
     pub fn is_percussion(self) -> bool {
         matches!(
             self,
@@ -105,6 +107,7 @@ impl InstrumentType {
 
     /// General MIDI drum note for percussion instruments.
     /// Returns `None` for melodic instruments.
+    #[allow(dead_code)]
     pub fn gm_drum_note(self) -> Option<u8> {
         match self {
             InstrumentType::Kick => Some(36),        // Acoustic Bass Drum
@@ -125,6 +128,7 @@ impl InstrumentType {
 
     /// Comfortable MIDI note range (low, high) for melodic instruments.
     /// For percussion, returns `(note, note)` with the GM drum note.
+    #[allow(dead_code)]
     pub fn midi_range(self) -> (u8, u8) {
         if let Some(note) = self.gm_drum_note() {
             return (note, note);
@@ -269,6 +273,7 @@ pub struct Pattern {
 }
 
 impl Pattern {
+    #[allow(dead_code)]
     pub fn empty(bars: u32) -> Self {
         Self {
             events: Vec::new(),
@@ -431,11 +436,13 @@ impl Song {
     }
 
     /// Total bar count from the song structure.
+    #[allow(dead_code)]
     pub fn total_bars(&self) -> u32 {
         self.structure.iter().map(|p| p.typical_bars()).sum()
     }
 
     /// Total length in ticks.
+    #[allow(dead_code)]
     pub fn total_ticks(&self) -> u32 {
         self.total_bars() * super::TICKS_PER_BAR
     }

--- a/src/engine/theory.rs
+++ b/src/engine/theory.rs
@@ -26,6 +26,7 @@ pub enum PitchClass {
 
 impl PitchClass {
     /// All 12 pitch classes in chromatic order.
+    #[allow(dead_code)]
     pub const ALL: [PitchClass; 12] = [
         PitchClass::C,
         PitchClass::Cs,
@@ -42,16 +43,19 @@ impl PitchClass {
     ];
 
     /// Convert a MIDI note number to its pitch class.
+    #[allow(dead_code)]
     pub fn from_midi(note: u8) -> Self {
         PitchClass::ALL[(note % 12) as usize]
     }
 
     /// Semitone offset from C (0–11).
+    #[allow(dead_code)]
     pub fn to_semitone(self) -> u8 {
         self as u8
     }
 
     /// Transpose by a signed number of semitones.
+    #[allow(dead_code)]
     pub fn transpose(self, semitones: i8) -> Self {
         let val = (self.to_semitone() as i16 + semitones as i16).rem_euclid(12) as u8;
         PitchClass::ALL[val as usize]
@@ -146,6 +150,7 @@ impl ScaleType {
 
     /// For scales with fewer than 7 notes, return the parent diatonic intervals
     /// used for chord derivation.
+    #[allow(dead_code)]
     pub fn parent_diatonic_intervals(self) -> &'static [u8] {
         match self {
             ScaleType::MinorPentatonic | ScaleType::Blues => ScaleType::NaturalMinor.intervals(),
@@ -197,6 +202,7 @@ impl Scale {
     }
 
     /// Concrete pitch classes for the enabled degrees.
+    #[allow(dead_code)]
     pub fn pitch_classes(&self) -> Vec<PitchClass> {
         self.scale_type
             .intervals()
@@ -208,12 +214,14 @@ impl Scale {
     }
 
     /// Test whether a pitch class belongs to this scale (considering enabled degrees).
+    #[allow(dead_code)]
     pub fn contains(&self, pitch: PitchClass) -> bool {
         self.pitch_classes().contains(&pitch)
     }
 
     /// Return the nth scale degree (0-based) as a pitch class.
     /// Returns `None` if `n` is out of range or the degree is disabled.
+    #[allow(dead_code)]
     pub fn degree(&self, n: usize) -> Option<PitchClass> {
         let intervals = self.scale_type.intervals();
         if n >= intervals.len() {
@@ -227,6 +235,7 @@ impl Scale {
 
     /// Derive diatonic triads for each of the 7 scale degrees.
     /// For pentatonic/blues, uses the parent diatonic scale.
+    #[allow(dead_code)]
     pub fn diatonic_chords(&self) -> Vec<(ChordDegree, ChordQuality)> {
         let intervals = self.scale_type.parent_diatonic_intervals();
         if intervals.len() < 7 {
@@ -272,6 +281,7 @@ impl Scale {
 // ChordQuality
 // ---------------------------------------------------------------------------
 
+#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ChordQuality {
@@ -289,6 +299,7 @@ pub enum ChordQuality {
 
 impl ChordQuality {
     /// Semitone offsets from root for this chord quality.
+    #[allow(dead_code)]
     pub fn intervals(self) -> &'static [u8] {
         match self {
             ChordQuality::Major => &[0, 4, 7],
@@ -322,6 +333,7 @@ pub enum ChordDegree {
 }
 
 impl ChordDegree {
+    #[allow(dead_code)]
     pub const ALL: [ChordDegree; 7] = [
         ChordDegree::I,
         ChordDegree::II,
@@ -333,6 +345,7 @@ impl ChordDegree {
     ];
 
     /// Zero-based index (I=0, VII=6).
+    #[allow(dead_code)]
     pub fn to_index(self) -> usize {
         self as usize
     }
@@ -387,6 +400,7 @@ impl<'de> Deserialize<'de> for ChordDegree {
 // Chord
 // ---------------------------------------------------------------------------
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Chord {
     pub root: PitchClass,
@@ -398,6 +412,7 @@ pub struct Chord {
 
 impl Chord {
     /// Return the pitch classes in this chord based on root and quality.
+    #[allow(dead_code)]
     pub fn notes(&self) -> Vec<PitchClass> {
         self.quality
             .intervals()
@@ -412,6 +427,7 @@ impl Chord {
 // ---------------------------------------------------------------------------
 
 /// Named intervals with their semitone distances.
+#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Interval {
@@ -432,6 +448,7 @@ pub enum Interval {
 
 impl Interval {
     /// Semitone distance for this interval.
+    #[allow(dead_code)]
     pub fn semitones(self) -> u8 {
         match self {
             Interval::Unison => 0,
@@ -452,6 +469,7 @@ impl Interval {
 
     /// Create an interval from a semitone count (0-12).
     /// Returns `None` for values outside this range.
+    #[allow(dead_code)]
     pub fn from_semitones(semitones: u8) -> Option<Self> {
         match semitones {
             0 => Some(Interval::Unison),
@@ -472,6 +490,7 @@ impl Interval {
     }
 
     /// Compute the interval between two pitch classes (ascending, 0-11 semitones).
+    #[allow(dead_code)]
     pub fn between(from: PitchClass, to: PitchClass) -> Option<Self> {
         let diff = (to.to_semitone() as i16 - from.to_semitone() as i16).rem_euclid(12) as u8;
         Self::from_semitones(diff)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use anyhow::Result;
 use clap::Parser;
 

--- a/src/midi_export.rs
+++ b/src/midi_export.rs
@@ -3,6 +3,8 @@
 // Converts a `Song` into a Standard MIDI File (Type 1, multi-track)
 // with 480 ticks per beat, tempo meta events, track names, and
 // note/CC/pitch-bend events.
+// Fully implemented — awaiting GUI integration (v0.4.0).
+#![allow(dead_code)]
 
 use anyhow::Result;
 use midly::num::{u14, u15, u24, u28, u4, u7};

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,3 +1,6 @@
+// State management, IPC protocol — awaiting GUI integration (v0.4.0).
+#![allow(dead_code)]
+
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};


### PR DESCRIPTION
## Summary
- Removed the blanket `#![allow(dead_code)]` from `src/main.rs` that suppressed dead code warnings across the entire crate
- Added module-level `#![allow(dead_code)]` for 9 fully-implemented modules awaiting GUI integration (v0.4.0): arrangement, bass, composer, drums, melody, pads, rhythm, midi_export, state
- Added per-item `#[allow(dead_code)]` for specific unused methods/constants in partially-used modules: engine/mod.rs (4 constants), song.rs (7 methods), theory.rs (20 items)
- All 270 existing tests pass, `cargo clippy -- -D warnings` is clean, zero build warnings

Closes #84

## Test plan
- [x] `cargo build --release` produces zero warnings
- [x] `cargo test` — all 270 tests pass
- [x] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)