### PR TITLE
feat: wire compose and export-midi to real engine (closes #101)

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,14 +1,17 @@
 use anyhow::Result;
+use std::path::Path;
 
 use crate::engine::song::{InstrumentType, Pattern, SongPart, StrumPattern};
 use crate::engine::theory::ScaleType;
+use crate::midi_export;
 use crate::state::AppState;
 
 use super::{Cli, Commands};
 
-/// Execute a CLI command and print JSON to stdout.
-pub fn execute(command: &Commands, args: &Cli) -> Result<()> {
-    let response = match command {
+/// Build the JSON response for a CLI command.
+/// Extracted from `execute` for testability.
+fn build_response(command: &Commands, args: &Cli) -> serde_json::Value {
+    match command {
         Commands::ListScales => {
             let scales = vec![
                 ScaleType::Major,
@@ -115,14 +118,53 @@ pub fn execute(command: &Commands, args: &Cli) -> Result<()> {
                 }
             }
         }
+        Commands::Compose => {
+            let seed = args.seed.unwrap_or(42);
+            let mut state = AppState::new(seed);
+            state.composer.compose(&mut state.song);
+            serde_json::json!({"ok": true, "data": state.song})
+        }
+        Commands::ExportMidi { path, .. } => {
+            let seed = args.seed.unwrap_or(42);
+            let mut state = AppState::new(seed);
+            state.composer.compose(&mut state.song);
+            let export_path = Path::new(path);
+            match midi_export::export_to_file(&state.song, export_path) {
+                Ok(()) => serde_json::json!({
+                    "ok": true,
+                    "data": {
+                        "path": path,
+                        "tracks": state.song.tracks.len(),
+                        "bars": state.song.total_bars()
+                    }
+                }),
+                Err(e) => serde_json::json!({
+                    "ok": false,
+                    "error": format!("MIDI export failed: {e}")
+                }),
+            }
+        }
         _ => serde_json::json!({"ok": true, "data": "not yet implemented"}),
-    };
+    }
+}
+
+/// Execute a CLI command and print JSON to stdout.
+pub fn execute(command: &Commands, args: &Cli) -> Result<()> {
+    let response = build_response(command, args);
 
     if args.json_pretty {
         println!("{}", serde_json::to_string_pretty(&response)?);
     } else {
         println!("{}", serde_json::to_string(&response)?);
     }
+
+    // Non-zero exit for failed compose/export-midi per production quality standards
+    if matches!(command, Commands::Compose | Commands::ExportMidi { .. })
+        && response.get("ok") == Some(&serde_json::Value::Bool(false))
+    {
+        std::process::exit(1);
+    }
+
     Ok(())
 }
 
@@ -130,119 +172,9 @@ pub fn execute(command: &Commands, args: &Cli) -> Result<()> {
 mod tests {
     use super::*;
 
-    /// Helper: execute a command and capture the JSON response.
+    /// Helper: build a command response for testing.
     fn exec_json(command: &Commands, args: &Cli) -> serde_json::Value {
-        // We can't easily capture stdout, so test the logic directly
-        let response = match command {
-            Commands::ListScales => {
-                let scales = vec![
-                    ScaleType::Major,
-                    ScaleType::NaturalMinor,
-                    ScaleType::HarmonicMinor,
-                    ScaleType::Dorian,
-                    ScaleType::Mixolydian,
-                    ScaleType::MinorPentatonic,
-                    ScaleType::Blues,
-                ];
-                serde_json::json!({"ok": true, "data": scales})
-            }
-            Commands::ListInstruments => {
-                let instruments = vec![
-                    InstrumentType::AcousticGuitar,
-                    InstrumentType::ElectricGuitar,
-                    InstrumentType::ElectricBass,
-                    InstrumentType::AcousticBass,
-                    InstrumentType::PedalSteel,
-                    InstrumentType::Mandolin,
-                    InstrumentType::Banjo,
-                    InstrumentType::HammondOrgan,
-                    InstrumentType::Piano,
-                    InstrumentType::Pad,
-                    InstrumentType::Kick,
-                    InstrumentType::Snare,
-                    InstrumentType::HiHat,
-                    InstrumentType::OpenHiHat,
-                    InstrumentType::Clap,
-                    InstrumentType::Tambourine,
-                    InstrumentType::Cowbell,
-                    InstrumentType::Shaker,
-                    InstrumentType::RideCymbal,
-                    InstrumentType::CrashCymbal,
-                    InstrumentType::Toms,
-                    InstrumentType::Rimshot,
-                ];
-                serde_json::json!({"ok": true, "data": instruments})
-            }
-            Commands::ListParts => {
-                let parts = vec![
-                    SongPart::Intro,
-                    SongPart::Verse,
-                    SongPart::PreChorus,
-                    SongPart::Chorus,
-                    SongPart::Bridge,
-                    SongPart::Outro,
-                ];
-                serde_json::json!({"ok": true, "data": parts})
-            }
-            Commands::ListStrumPatterns => {
-                let patterns = vec![StrumPattern::default_folk()];
-                serde_json::json!({"ok": true, "data": patterns})
-            }
-            Commands::GetState => {
-                let seed = args.seed.unwrap_or(42);
-                let state = AppState::new(seed);
-                serde_json::json!({"ok": true, "data": state})
-            }
-            Commands::GetSong => {
-                let seed = args.seed.unwrap_or(42);
-                let state = AppState::new(seed);
-                serde_json::json!({"ok": true, "data": state.song})
-            }
-            Commands::GetTrack { index } => {
-                let seed = args.seed.unwrap_or(42);
-                let state = AppState::new(seed);
-                if *index >= state.song.tracks.len() {
-                    serde_json::json!({"ok": false, "error": format!("Track index {} out of range (0-{})", index, state.song.tracks.len() - 1)})
-                } else {
-                    serde_json::json!({"ok": true, "data": state.song.tracks[*index]})
-                }
-            }
-            Commands::GetPattern { track, part } => {
-                let seed = args.seed.unwrap_or(42);
-                let state = AppState::new(seed);
-                match part.parse::<SongPart>() {
-                    Err(e) => serde_json::json!({"ok": false, "error": e.to_string()}),
-                    Ok(song_part) => {
-                        if *track >= state.song.tracks.len() {
-                            serde_json::json!({"ok": false, "error": format!("Track index {} out of range (0-{})", track, state.song.tracks.len() - 1)})
-                        } else {
-                            match state.song.tracks[*track].patterns.get(&song_part) {
-                                Some(pattern) => serde_json::json!({"ok": true, "data": pattern}),
-                                None => {
-                                    let empty = Pattern::empty(song_part.typical_bars());
-                                    serde_json::json!({"ok": true, "data": empty})
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            Commands::ListProgressions { part } => {
-                let seed = args.seed.unwrap_or(42);
-                let state = AppState::new(seed);
-                match part.parse::<SongPart>() {
-                    Err(e) => serde_json::json!({"ok": false, "error": e.to_string()}),
-                    Ok(song_part) => {
-                        match state.song.progressions.get(&song_part) {
-                            Some(prog) => serde_json::json!({"ok": true, "data": prog}),
-                            None => serde_json::json!({"ok": true, "data": []}),
-                        }
-                    }
-                }
-            }
-            _ => serde_json::json!({"ok": true, "data": "not yet implemented"}),
-        };
-        response
+        build_response(command, args)
     }
 
     fn default_args() -> Cli {
@@ -360,6 +292,7 @@ mod tests {
             Commands::ListStrumPatterns,
             Commands::GetState,
             Commands::GetSong,
+            Commands::Compose,
         ];
         for cmd in &commands {
             let resp = exec_json(cmd, &args);
@@ -475,8 +408,186 @@ mod tests {
 
     #[test]
     fn unimplemented_command_returns_stub() {
-        let resp = exec_json(&Commands::Compose, &default_args());
+        // Compose and ExportMidi are now wired; test with a still-unimplemented command
+        let resp = exec_json(&Commands::Undo, &default_args());
         assert_eq!(resp["ok"], true);
         assert_eq!(resp["data"], "not yet implemented");
+    }
+
+    // -- Compose tests -------------------------------------------------------
+
+    #[test]
+    fn compose_returns_populated_song() {
+        let resp = exec_json(&Commands::Compose, &default_args());
+        assert_eq!(resp["ok"], true);
+        let tracks = resp["data"]["tracks"].as_array().expect("tracks array");
+        assert_eq!(tracks.len(), 16);
+
+        // At least some tracks should have populated patterns
+        let has_patterns = tracks.iter().any(|t| {
+            t.get("patterns")
+                .and_then(|p| p.as_object())
+                .map(|p| !p.is_empty())
+                .unwrap_or(false)
+        });
+        assert!(has_patterns, "composed song should have populated patterns");
+    }
+
+    #[test]
+    fn compose_is_deterministic() {
+        let mut args = default_args();
+        args.seed = Some(42);
+        let resp1 = exec_json(&Commands::Compose, &args);
+        let resp2 = exec_json(&Commands::Compose, &args);
+        assert_eq!(resp1, resp2, "same seed should produce identical output");
+    }
+
+    #[test]
+    fn compose_different_seeds_differ() {
+        let mut args1 = default_args();
+        args1.seed = Some(42);
+        let mut args2 = default_args();
+        args2.seed = Some(99);
+        let resp1 = exec_json(&Commands::Compose, &args1);
+        let resp2 = exec_json(&Commands::Compose, &args2);
+        assert_ne!(resp1, resp2, "different seeds should produce different output");
+    }
+
+    #[test]
+    fn compose_tracks_have_note_events() {
+        let mut args = default_args();
+        args.seed = Some(42);
+        let resp = exec_json(&Commands::Compose, &args);
+        let tracks = resp["data"]["tracks"].as_array().expect("tracks array");
+
+        // Acoustic Guitar (index 4) is active in all parts and should have events
+        let guitar = &tracks[4];
+        let patterns = guitar["patterns"].as_object().expect("patterns object");
+        assert!(!patterns.is_empty(), "guitar should have patterns");
+
+        let has_events = patterns.values().any(|p| {
+            p["events"]
+                .as_array()
+                .map(|e| !e.is_empty())
+                .unwrap_or(false)
+        });
+        assert!(has_events, "guitar patterns should have note events");
+    }
+
+    #[test]
+    fn compose_respects_seed_arg() {
+        let mut args = default_args();
+        args.seed = Some(12345);
+        let resp = exec_json(&Commands::Compose, &args);
+        assert_eq!(resp["ok"], true);
+
+        // Verify composition actually happened (not just default empty song)
+        let tracks = resp["data"]["tracks"].as_array().expect("tracks array");
+        let total_patterns: usize = tracks.iter().map(|t| {
+            t["patterns"].as_object().map(|p| p.len()).unwrap_or(0)
+        }).sum();
+        assert!(total_patterns > 0, "composed song should have patterns");
+    }
+
+    // -- ExportMidi tests ----------------------------------------------------
+
+    #[test]
+    fn export_midi_creates_file() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("copper_hollow_cmd_test.mid");
+        let path_str = path.to_string_lossy().to_string();
+
+        let resp = exec_json(
+            &Commands::ExportMidi {
+                path: path_str.clone(),
+                track: None,
+                part: None,
+            },
+            &default_args(),
+        );
+        assert_eq!(resp["ok"], true);
+        assert_eq!(resp["data"]["path"], path_str);
+        assert_eq!(resp["data"]["tracks"], 16);
+        assert_eq!(resp["data"]["bars"], 64);
+
+        // Verify file exists on disk
+        assert!(path.exists(), "MIDI file should exist on disk");
+
+        // Verify file is valid MIDI that can be read back
+        let data = std::fs::read(&path).expect("read MIDI file");
+        let parsed = midly::Smf::parse(&data).expect("parse MIDI");
+        assert_eq!(parsed.tracks.len(), 17); // 1 conductor + 16 instrument
+
+        // Verify at least some tracks have note events
+        let total_note_ons: usize = parsed
+            .tracks
+            .iter()
+            .skip(1)
+            .map(|t| {
+                t.iter()
+                    .filter(|ev| {
+                        matches!(
+                            ev.kind,
+                            midly::TrackEventKind::Midi {
+                                message: midly::MidiMessage::NoteOn { .. },
+                                ..
+                            }
+                        )
+                    })
+                    .count()
+            })
+            .sum();
+        assert!(total_note_ons > 0, "exported MIDI should contain notes");
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn export_midi_invalid_path_returns_error() {
+        let resp = exec_json(
+            &Commands::ExportMidi {
+                path: "/nonexistent/dir/test.mid".to_string(),
+                track: None,
+                part: None,
+            },
+            &default_args(),
+        );
+        assert_eq!(resp["ok"], false);
+        let err = resp["error"].as_str().expect("error should be string");
+        assert!(err.contains("MIDI export failed"));
+    }
+
+    #[test]
+    fn export_midi_deterministic() {
+        let dir = std::env::temp_dir();
+        let path1 = dir.join("copper_hollow_det_test_1.mid");
+        let path2 = dir.join("copper_hollow_det_test_2.mid");
+
+        let mut args = default_args();
+        args.seed = Some(42);
+
+        exec_json(
+            &Commands::ExportMidi {
+                path: path1.to_string_lossy().to_string(),
+                track: None,
+                part: None,
+            },
+            &args,
+        );
+        exec_json(
+            &Commands::ExportMidi {
+                path: path2.to_string_lossy().to_string(),
+                track: None,
+                part: None,
+            },
+            &args,
+        );
+
+        let bytes1 = std::fs::read(&path1).expect("read file 1");
+        let bytes2 = std::fs::read(&path2).expect("read file 2");
+        assert_eq!(bytes1, bytes2, "same seed should produce identical MIDI files");
+
+        std::fs::remove_file(&path1).ok();
+        std::fs::remove_file(&path2).ok();
     }
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1,0 +1,131 @@
+//! Integration tests for CLI compose and export-midi commands.
+//! These run the actual binary and verify JSON output, exit codes, and MIDI files on disk.
+
+use std::process::Command;
+
+fn binary() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_copper-hollow"))
+}
+
+#[test]
+fn cli_compose_returns_valid_json_with_patterns() {
+    let output = binary()
+        .args(["--seed", "42", "compose"])
+        .output()
+        .expect("failed to execute");
+
+    assert!(output.status.success(), "compose should exit 0");
+
+    let stdout = String::from_utf8(output.stdout).expect("valid utf8");
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(json["ok"], true);
+
+    let tracks = json["data"]["tracks"].as_array().expect("tracks array");
+    assert_eq!(tracks.len(), 16);
+
+    // At least some tracks should have patterns with note events
+    let has_events = tracks.iter().any(|t| {
+        t["patterns"]
+            .as_object()
+            .map(|p| {
+                p.values().any(|pat| {
+                    pat["events"]
+                        .as_array()
+                        .map(|e| !e.is_empty())
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false)
+    });
+    assert!(has_events, "composed song should have note events");
+}
+
+#[test]
+fn cli_compose_is_deterministic() {
+    let run = || {
+        let output = binary()
+            .args(["--seed", "42", "compose"])
+            .output()
+            .expect("failed to execute");
+        assert!(output.status.success());
+        String::from_utf8(output.stdout).expect("valid utf8")
+    };
+
+    let first = run();
+    let second = run();
+    assert_eq!(first, second, "same seed must produce identical output");
+}
+
+#[test]
+fn cli_export_midi_creates_valid_file() {
+    let dir = std::env::temp_dir();
+    let path = dir.join("copper_hollow_integration_test.mid");
+    let path_str = path.to_string_lossy().to_string();
+
+    // Clean up from previous runs
+    let _ = std::fs::remove_file(&path);
+
+    let output = binary()
+        .args(["--seed", "42", "export-midi", &path_str])
+        .output()
+        .expect("failed to execute");
+
+    assert!(output.status.success(), "export-midi should exit 0");
+
+    let stdout = String::from_utf8(output.stdout).expect("valid utf8");
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["data"]["path"], path_str);
+    assert_eq!(json["data"]["tracks"], 16);
+    assert_eq!(json["data"]["bars"], 64);
+
+    // Verify file exists and is valid MIDI
+    assert!(path.exists(), "MIDI file should exist on disk");
+    let midi_bytes = std::fs::read(&path).expect("read MIDI file");
+    let smf = midly::Smf::parse(&midi_bytes).expect("valid MIDI");
+    assert_eq!(smf.tracks.len(), 17); // 1 conductor + 16 instrument tracks
+
+    // Verify it has actual note content
+    let total_notes: usize = smf
+        .tracks
+        .iter()
+        .skip(1)
+        .map(|t| {
+            t.iter()
+                .filter(|ev| {
+                    matches!(
+                        ev.kind,
+                        midly::TrackEventKind::Midi {
+                            message: midly::MidiMessage::NoteOn { .. },
+                            ..
+                        }
+                    )
+                })
+                .count()
+        })
+        .sum();
+    assert!(total_notes > 0, "MIDI file should contain notes");
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn cli_export_midi_invalid_path_exits_nonzero() {
+    let output = binary()
+        .args(["--seed", "42", "export-midi", "/nonexistent/dir/test.mid"])
+        .output()
+        .expect("failed to execute");
+
+    assert!(
+        !output.status.success(),
+        "export-midi to invalid path should exit non-zero"
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("valid utf8");
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(json["ok"], false);
+    assert!(json["error"]
+        .as_str()
+        .expect("error string")
+        .contains("MIDI export failed"));
+}


### PR DESCRIPTION
## Summary

- **compose command**: Creates `AppState` with the requested seed, calls `Composer::compose()` to populate all track patterns, returns the fully composed song as JSON. Same seed + same settings = identical output.
- **export-midi command**: Composes the song (same pipeline as compose), then calls `midi_export::export_to_file()` to write a valid Standard MIDI File to disk. Returns `{ok: true, data: {path, tracks, bars}}` on success, or `{ok: false, error: "..."}` with non-zero exit code on I/O failure.
- **Eliminated test helper duplication**: Extracted `build_response()` from `execute()` so the test helper `exec_json()` calls the same code path as production, rather than duplicating all match arms.

### Design decisions

- **Full-song export only**: The `--track` and `--part` flags on `export-midi` are accepted but not used for filtering — the full song is always exported. Single-track export can be added in a future issue.
- **Non-zero exit on failure**: `export-midi` prints error JSON to stdout then calls `process::exit(1)` when the MIDI file write fails, satisfying the production quality requirement that failed commands return non-zero exit codes.
- **No changes to other stubs**: Commands still in the `_ =>` catch-all (e.g., `set-tempo`, `undo`) continue returning the existing stub response. Fixing those is tracked separately in #100.

## Test plan

- [x] `compose --seed 42` returns valid JSON with 16 tracks and populated patterns (unit + integration)
- [x] `compose --seed 42` is deterministic — same output on repeated runs (unit + integration)
- [x] Different seeds produce different compositions (unit)
- [x] `export-midi --seed 42 /tmp/test.mid` creates a valid MIDI file on disk (unit + integration)
- [x] Exported MIDI can be read back with midly: 17 tracks (1 conductor + 16 instrument), contains note events (unit + integration)
- [x] `export-midi` to invalid path returns `ok: false` with error message (unit)
- [x] `export-midi` to invalid path exits non-zero (integration)
- [x] All 290 unit tests pass
- [x] All 4 integration tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo build --release` succeeds

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)