### PR TITLE
fix: guard usize underflow panic in GetTrack/GetPattern (closes #143)

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -79,7 +79,9 @@ fn build_response(command: &Commands, args: &Cli) -> serde_json::Value {
         Commands::GetTrack { index } => {
             let seed = args.seed.unwrap_or(42);
             let state = AppState::new(seed);
-            if *index >= state.song.tracks.len() {
+            if state.song.tracks.is_empty() {
+                serde_json::json!({"ok": false, "error": "no tracks in song"})
+            } else if *index >= state.song.tracks.len() {
                 serde_json::json!({"ok": false, "error": format!("Track index {} out of range (0-{})", index, state.song.tracks.len() - 1)})
             } else {
                 serde_json::json!({"ok": true, "data": state.song.tracks[*index]})
@@ -91,7 +93,9 @@ fn build_response(command: &Commands, args: &Cli) -> serde_json::Value {
             match part.parse::<SongPart>() {
                 Err(e) => serde_json::json!({"ok": false, "error": e.to_string()}),
                 Ok(song_part) => {
-                    if *track >= state.song.tracks.len() {
+                    if state.song.tracks.is_empty() {
+                        serde_json::json!({"ok": false, "error": "no tracks in song"})
+                    } else if *track >= state.song.tracks.len() {
                         serde_json::json!({"ok": false, "error": format!("Track index {} out of range (0-{})", track, state.song.tracks.len() - 1)})
                     } else {
                         match state.song.tracks[*track].patterns.get(&song_part) {


### PR DESCRIPTION
## Summary
- Added `is_empty()` guards before `tracks.len() - 1` arithmetic in both `GetTrack` and `GetPattern` handlers of `build_response()` in `src/cli/commands.rs`
- When `tracks` is empty, the handlers now return `{"ok": false, "error": "no tracks in song"}` instead of panicking on usize underflow
- Supersedes closed PR #115 which targeted pre-refactor code

## What changed
**Lines 82-86** (`GetTrack`): Added `state.song.tracks.is_empty()` check before the existing `index >= len()` check, preventing `len() - 1` from underflowing.

**Lines 96-100** (`GetPattern`): Same guard added in the `Ok(song_part)` branch before the track bounds check.

## Why
`usize` subtraction (`tracks.len() - 1`) panics in debug mode and wraps to `usize::MAX` in release mode when `tracks.len()` is 0. Both behaviors are wrong — a panic crashes the process, and `usize::MAX` produces a nonsensical error message. The fix returns a clear error response instead.

## Test plan
- [x] `cargo build --release` — compiles cleanly
- [x] `cargo test` — 310 tests pass (306 unit + 4 integration)
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] Existing `get_track_out_of_range_returns_error` and `get_pattern_track_out_of_range_returns_error` tests continue to pass (these exercise the `len() - 1` path with non-empty tracks)

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)