### PR TITLE
ci: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable with clippy
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build
+        run: cargo build --release
+
+      - name: Test
+        run: cargo test
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` that runs on push to `main` and on PRs targeting `main`
- Runs `cargo build --release`, `cargo test`, and `cargo clippy -- -D warnings` on ubuntu-latest with Rust stable
- Caches cargo dependencies for faster runs
- Complements the RALPH monitor phase with automated CI checks

## Test plan
- [ ] Verify the workflow triggers on this PR
- [ ] Confirm build, test, and clippy steps pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)